### PR TITLE
feat: simplify library API

### DIFF
--- a/packages/node-fhir-server-core/src/constants.js
+++ b/packages/node-fhir-server-core/src/constants.js
@@ -1,57 +1,56 @@
-exports.ISSUE = {
-  SEVERITY: {
-    FATAL: 'fatal',
-    ERROR: 'error',
-    WARNING: 'warning',
-    INFO: 'information',
-  },
-  // Codes defined here: https://www.hl7.org/fhir/valueset-issue-type.html
-  CODE: {
-    // Invalid can be seen as a parent essentially to these, see Level on above url
-    // This means structure, required, value, and invariant, are all also invalid
-    // you can send invalid back or something more specific
-    INVALID: 'invalid',
-    STRUCTURE: 'structure',
-    REQUIRED: 'required',
-    VALUE: 'value',
-    INVARIANT: 'invariant',
-    // Security is parent of login, unknown, expired, forbidden, and surpressed
-    SECURITY: 'security',
-    LOGIN: 'login',
-    UNKNOWN: 'unknown',
-    EXPIRED: 'expired',
-    FORBIDDEN: 'forbidden',
-    SUPPRESSED: 'surpressed',
-    // Procesing has no parent/children
-    PROCESSING: 'processing',
-    // Not Supported is parent of duplicate, not found, and too long
-    NOT_SUPPORTED: 'not-supported',
-    DUPLICATE: 'duplicate',
-    NOT_FOUND: 'not-found',
-    TOO_LONG: 'too-long',
-    // Code invalid is parent of extension, too costly, business rule, conflict, and incomplete
-    CODE_INVALID: 'code-invalid',
-    EXTENSION: 'extension',
-    TOO_COSTLY: 'too-costly',
-    BUSINESS_RULE: 'business-rule',
-    CONFLICT: 'conflict',
-    INCOMPLETE: 'incomplete',
-    // Transient is parent of lock error, no store, exception, timeout, and throttled
-    TRANSIENT: 'transient',
-    LOCK_ERROR: 'lock-error',
-    NO_STORE: 'no-store',
-    EXCEPTION: 'exception',
-    TIMEOUT: 'timeout',
-    THROTTLED: 'throttled',
-    // Informational has no parent/children
-    INFORMATIONAL: 'informational',
-  },
+const SEVERITY = {
+  FATAL: 'fatal',
+  ERROR: 'error',
+  WARNING: 'warning',
+  INFO: 'information'
+};
+
+// Codes defined here: https://www.hl7.org/fhir/valueset-issue-type.html
+const CODE = {
+  // Invalid can be seen as a parent essentially to these, see Level on above url
+  // This means structure, required, value, and invariant, are all also invalid
+  // you can send invalid back or something more specific
+  INVALID: 'invalid',
+  STRUCTURE: 'structure',
+  REQUIRED: 'required',
+  VALUE: 'value',
+  INVARIANT: 'invariant',
+  // Security is parent of login, unknown, expired, forbidden, and surpressed
+  SECURITY: 'security',
+  LOGIN: 'login',
+  UNKNOWN: 'unknown',
+  EXPIRED: 'expired',
+  FORBIDDEN: 'forbidden',
+  SUPPRESSED: 'surpressed',
+  // Procesing has no parent/children
+  PROCESSING: 'processing',
+  // Not Supported is parent of duplicate, not found, and too long
+  NOT_SUPPORTED: 'not-supported',
+  DUPLICATE: 'duplicate',
+  NOT_FOUND: 'not-found',
+  TOO_LONG: 'too-long',
+  // Code invalid is parent of extension, too costly, business rule, conflict, and incomplete
+  CODE_INVALID: 'code-invalid',
+  EXTENSION: 'extension',
+  TOO_COSTLY: 'too-costly',
+  BUSINESS_RULE: 'business-rule',
+  CONFLICT: 'conflict',
+  INCOMPLETE: 'incomplete',
+  // Transient is parent of lock error, no store, exception, timeout, and throttled
+  TRANSIENT: 'transient',
+  LOCK_ERROR: 'lock-error',
+  NO_STORE: 'no-store',
+  EXCEPTION: 'exception',
+  TIMEOUT: 'timeout',
+  THROTTLED: 'throttled',
+  // Informational has no parent/children
+  INFORMATIONAL: 'informational'
 };
 
 /**
  * Interactions Types.  Also the name of the controller methods
  */
-exports.INTERACTIONS = {
+const INTERACTIONS = {
   SEARCH: 'search',
   SEARCH_BY_ID: 'searchById',
   SEARCH_BY_VID: 'searchByVersionId',
@@ -62,27 +61,36 @@ exports.INTERACTIONS = {
   DELETE: 'remove',
   PATCH: 'patch',
   OPERATIONS_POST: 'operationsPost',
-  OPERATIONS_GET: 'operationsGet',
+  OPERATIONS_GET: 'operationsGet'
 };
 
 /**
  * These are currently the only versions we support
  */
-exports.VERSIONS = {
+const VERSIONS = {
   '1_0_2': '1_0_2',
   '2_0_0': '2_0_0',
   '3_0_1': '3_0_1',
-  '4_0_0': '4_0_0',
+  '4_0_0': '4_0_0'
 };
 
 /**
  * Custom events we support
  */
-exports.EVENTS = {
+const EVENTS = {
   AUDIT: 'audit-event',
-  PROVENANCE: 'provenance',
+  PROVENANCE: 'provenance'
 };
 
-exports.RESOURCES = {
-  PRACTITIONER: 'practitioner',
+const RESOURCES = {
+  PRACTITIONER: 'practitioner'
+};
+
+module.exports = {
+  SEVERITY,
+  CODE,
+  INTERACTIONS,
+  VERSIONS,
+  EVENTS,
+  RESOURCES
 };

--- a/packages/node-fhir-server-core/src/index.js
+++ b/packages/node-fhir-server-core/src/index.js
@@ -1,18 +1,39 @@
 const { resolveSchema } = require('./server/utils/schema.utils');
 const ServerError = require('./server/utils/server.error');
-const winston = require('./server/winston.js');
+const loggers = require('./server/winston.js');
 const Server = require('./server/server');
-const constants = require('./constants');
+const { SEVERITY, CODE, INTERACTIONS, VERSIONS, EVENTS, RESOURCES } = require('./constants');
 
-/**
- * @name exports
- * @description Export the server and some convenience methods for building a FHIR server
- */
 module.exports = {
   /**
-   * @description Export constants so users can have access to these
+   * @description Severity
    */
-  constants,
+  SEVERITY,
+
+  /**
+   * @description Value Set Issue Types https://www.hl7.org/fhir/valueset-issue-type.html
+   */
+  CODE,
+
+  /**
+   * @description Resource interaction types
+   */
+  INTERACTIONS,
+
+  /**
+   * @description FHIR Versions
+   */
+  VERSIONS,
+
+  /**
+   * @description Events like Auditing and Provenance
+   */
+  EVENTS,
+
+  /**
+   * @description Severity
+   */
+  RESOURCES,
 
   /**
    * @description Export Server Error class for people to throw from services
@@ -37,7 +58,7 @@ module.exports = {
    * @description Export logger to allow for customization and easy access to
    * various loggers
    */
-  loggers: winston,
+  loggers,
 
   /**
    * @description Initialize is useful for building a server with all the defaults

--- a/packages/node-fhir-server-core/src/server/utils/error.utils.js
+++ b/packages/node-fhir-server-core/src/server/utils/error.utils.js
@@ -1,8 +1,8 @@
-const { ISSUE, VERSIONS } = require('../../constants');
+const { SEVERITY, CODE, VERSIONS } = require('../../constants');
 const { resolveSchema } = require('./schema.utils');
 
 // Helper to determine which operation outcome to retrieve
-let getErrorConstructor = (baseVersion) => {
+let getErrorConstructor = baseVersion => {
   if (!baseVersion || !Object.prototype.hasOwnProperty.call(VERSIONS, baseVersion)) {
     return resolveSchema(VERSIONS['3_0_1'], 'OperationOutcome');
   } else {
@@ -24,13 +24,13 @@ let invalidParameter = (message, base_version) => {
     statusCode: 400,
     text: {
       status: 'generated',
-      div: div_content(ISSUE.SEVERITY.ERROR, message),
+      div: div_content(SEVERITY.ERROR, message)
     },
     issue: {
-      code: ISSUE.CODE.INVALID,
-      severity: ISSUE.SEVERITY.ERROR,
-      diagnostics: message,
-    },
+      code: CODE.INVALID,
+      severity: SEVERITY.ERROR,
+      diagnostics: message
+    }
   });
 };
 
@@ -41,13 +41,13 @@ let unauthorized = (message, base_version) => {
     statusCode: 401,
     text: {
       status: 'generated',
-      div: div_content(ISSUE.SEVERITY.ERROR, message || 'Unauthorized request'),
+      div: div_content(SEVERITY.ERROR, message || 'Unauthorized request')
     },
     issue: {
-      code: ISSUE.CODE.FORBIDDEN,
-      severity: ISSUE.SEVERITY.ERROR,
-      diagnostics: message || '401: Unauthorized request',
-    },
+      code: CODE.FORBIDDEN,
+      severity: SEVERITY.ERROR,
+      diagnostics: message || '401: Unauthorized request'
+    }
   });
 };
 
@@ -57,13 +57,13 @@ let insufficientScope = (message, base_version) => {
     statusCode: 403,
     text: {
       status: 'generated',
-      div: div_content(ISSUE.SEVERITY.ERROR, message || 'Insufficient scope'),
+      div: div_content(SEVERITY.ERROR, message || 'Insufficient scope')
     },
     issue: {
-      code: ISSUE.CODE.FORBIDDEN,
-      severity: ISSUE.SEVERITY.ERROR,
-      diagnostics: message || '403: Insufficient scope',
-    },
+      code: CODE.FORBIDDEN,
+      severity: SEVERITY.ERROR,
+      diagnostics: message || '403: Insufficient scope'
+    }
   });
 };
 
@@ -73,13 +73,13 @@ let notFound = (message, base_version) => {
     statusCode: 404,
     text: {
       status: 'generated',
-      div: div_content(ISSUE.SEVERITY.ERROR, message || 'Not found'),
+      div: div_content(SEVERITY.ERROR, message || 'Not found')
     },
     issue: {
-      code: ISSUE.CODE.NOT_FOUND,
-      severity: ISSUE.SEVERITY.ERROR,
-      diagnostics: message || '404: Not found',
-    },
+      code: CODE.NOT_FOUND,
+      severity: SEVERITY.ERROR,
+      diagnostics: message || '404: Not found'
+    }
   });
 };
 
@@ -89,13 +89,13 @@ let methodNotAllowed = (message, base_version) => {
     statusCode: 405,
     text: {
       status: 'generated',
-      div: div_content(ISSUE.SEVERITY.ERROR, message || 'Method not allowed'),
+      div: div_content(SEVERITY.ERROR, message || 'Method not allowed')
     },
     issue: {
-      code: ISSUE.CODE.NOT_SUPPORTED,
-      severity: ISSUE.SEVERITY.ERROR,
-      diagnostics: message || '405: Method not allowed',
-    },
+      code: CODE.NOT_SUPPORTED,
+      severity: SEVERITY.ERROR,
+      diagnostics: message || '405: Method not allowed'
+    }
   });
 };
 
@@ -105,13 +105,13 @@ let deleteConflict = (message, base_version) => {
     statusCode: 409,
     text: {
       status: 'generated',
-      div: div_content(ISSUE.SEVERITY.ERROR, message || 'Conflict'),
+      div: div_content(SEVERITY.ERROR, message || 'Conflict')
     },
     issue: {
-      code: ISSUE.CODE.CONFLICT,
-      severity: ISSUE.SEVERITY.ERROR,
-      diagnostics: message || '409: Conflict',
-    },
+      code: CODE.CONFLICT,
+      severity: SEVERITY.ERROR,
+      diagnostics: message || '409: Conflict'
+    }
   });
 };
 
@@ -121,13 +121,13 @@ let deleted = (message, base_version) => {
     statusCode: 410,
     text: {
       status: 'generated',
-      div: div_content(ISSUE.SEVERITY.ERROR, message || 'Resource deleted'),
+      div: div_content(SEVERITY.ERROR, message || 'Resource deleted')
     },
     issue: {
-      code: ISSUE.CODE.NOT_FOUND,
-      severity: ISSUE.SEVERITY.ERROR,
-      diagnostics: message || '410: Resource deleted',
-    },
+      code: CODE.NOT_FOUND,
+      severity: SEVERITY.ERROR,
+      diagnostics: message || '410: Resource deleted'
+    }
   });
 };
 
@@ -144,14 +144,14 @@ let customError = (err, base_version) => {
     statusCode: err.statusCode,
     text: {
       status: 'generated',
-      div: div_content(err.severity, err.message),
+      div: div_content(err.severity, err.message)
     },
     issue: {
       code: err.code,
       severity: err.severity,
-      diagnostics: err.message,
+      diagnostics: err.message
     },
-    isCustom: true,
+    isCustom: true
   });
 };
 
@@ -166,13 +166,13 @@ let internal = (err, base_version) => {
     statusCode: 500,
     text: {
       status: 'generated',
-      div: div_content(ISSUE.SEVERITY.ERROR, err.message || 'Internal server error'),
+      div: div_content(SEVERITY.ERROR, err.message || 'Internal server error')
     },
     issue: {
-      code: ISSUE.CODE.EXCEPTION,
-      severity: ISSUE.SEVERITY.ERROR,
-      diagnostics: err.message || '500: Internal server error',
-    },
+      code: CODE.EXCEPTION,
+      severity: SEVERITY.ERROR,
+      diagnostics: err.message || '500: Internal server error'
+    }
   });
 };
 
@@ -193,5 +193,5 @@ module.exports = {
   deleted,
   internal,
   customError,
-  isServerError,
+  isServerError
 };

--- a/packages/node-fhir-server-core/src/server/utils/error.utils.test.js
+++ b/packages/node-fhir-server-core/src/server/utils/error.utils.test.js
@@ -5,10 +5,10 @@ const {
   notFound,
   deleted,
   internal,
-  isServerError,
+  isServerError
 } = require('./error.utils');
 
-const { ISSUE, VERSIONS } = require('../../constants');
+const { SEVERITY, CODE, VERSIONS } = require('../../constants');
 
 describe('Error Utils Tests', () => {
   test('should return correct OperationOutcome for an invalidParameter error', () => {
@@ -18,8 +18,8 @@ describe('Error Utils Tests', () => {
     expect(error.statusCode).toEqual(400);
     expect(error.issue).toHaveLength(1);
 
-    expect(issue.code).toBe(ISSUE.CODE.INVALID);
-    expect(issue.severity).toBe(ISSUE.SEVERITY.ERROR);
+    expect(issue.code).toBe(CODE.INVALID);
+    expect(issue.severity).toBe(SEVERITY.ERROR);
     expect(issue.diagnostics).toBe('Age is invalid.');
   });
 
@@ -34,8 +34,8 @@ describe('Error Utils Tests', () => {
     let issueWithoutMessage = errorWithoutMessage.issue[0];
 
     // Check the code and severity on one
-    expect(issueWithMessage.code).toBe(ISSUE.CODE.FORBIDDEN);
-    expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
+    expect(issueWithMessage.code).toBe(CODE.FORBIDDEN);
+    expect(issueWithoutMessage.severity).toBe(SEVERITY.ERROR);
 
     // Check the message for both
     expect(issueWithMessage.diagnostics).toBe('You shall not pass.');
@@ -56,8 +56,8 @@ describe('Error Utils Tests', () => {
     let issueWithoutMessage = errorWithoutMessage.issue[0];
 
     // Check the code and severity on one
-    expect(issueWithMessage.code).toBe(ISSUE.CODE.FORBIDDEN);
-    expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
+    expect(issueWithMessage.code).toBe(CODE.FORBIDDEN);
+    expect(issueWithoutMessage.severity).toBe(SEVERITY.ERROR);
 
     // Check the message for both
     expect(issueWithMessage.diagnostics).toBe('Not enough scope for this action.');
@@ -75,8 +75,8 @@ describe('Error Utils Tests', () => {
     let issueWithoutMessage = errorWithoutMessage.issue[0];
 
     // Check the code and severity on one
-    expect(issueWithMessage.code).toBe(ISSUE.CODE.NOT_FOUND);
-    expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
+    expect(issueWithMessage.code).toBe(CODE.NOT_FOUND);
+    expect(issueWithoutMessage.severity).toBe(SEVERITY.ERROR);
 
     // Check the message for both
     expect(issueWithMessage.diagnostics).toBe('Somthing not found.');
@@ -94,8 +94,8 @@ describe('Error Utils Tests', () => {
     let issueWithoutMessage = errorWithoutMessage.issue[0];
 
     // Check the code and severity on one
-    expect(issueWithMessage.code).toBe(ISSUE.CODE.NOT_FOUND);
-    expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
+    expect(issueWithMessage.code).toBe(CODE.NOT_FOUND);
+    expect(issueWithoutMessage.severity).toBe(SEVERITY.ERROR);
 
     // Check the message for both
     expect(issueWithMessage.diagnostics).toBe('This resource has been deleted.');
@@ -123,9 +123,9 @@ describe('Error Utils Tests', () => {
     let customIssueWithMessage = responseCustom.issue[0];
 
     // Check the code and severity on one
-    expect(issueWithMessage.code).toBe(ISSUE.CODE.EXCEPTION);
-    expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
-    expect(customIssueWithMessage.severity).toBe(ISSUE.SEVERITY.WARNING);
+    expect(issueWithMessage.code).toBe(CODE.EXCEPTION);
+    expect(issueWithoutMessage.severity).toBe(SEVERITY.ERROR);
+    expect(customIssueWithMessage.severity).toBe(SEVERITY.WARNING);
 
     // Check the message for both
     expect(issueWithMessage.diagnostics).toBe('Internal Server Error.');


### PR DESCRIPTION
This simplifies `node-fhir-server-core`'s API for developers. There was too much object unpacking and nested enumerations for a library.