### PR TITLE
feat: allow to specify request body size limit

### DIFF
--- a/docs/ServerConfiguration.md
+++ b/docs/ServerConfiguration.md
@@ -45,7 +45,8 @@ Here is an example config with all the currently supported options. See descript
 			key: 'path/to/key.pem',
 			cert: 'path/to.cert.pem'
 		},
-		publicDirectory: '/path/to/public'
+		publicDirectory: '/path/to/public',
+		requestSizeLimit: '10mb'
 	},
 	logging: {
 		level: 'debug'
@@ -191,6 +192,13 @@ const fhirConfig = {
 
 - **Type:** `string`
 - **Description:** Path to your public directory. Some certificate authorities need to validate your server, for example, Let's Encrypt. You can use this to enable a public directory to serve the challenge file from `/.well-known/acme-challenge`.
+- **Required:** No.
+- **Default:** `none`
+
+#### `server.requestSizeLimit`
+
+- **Type:** `string`
+- **Description:** Controls the maximum request body size. The value is passed to [body-parser](https://www.npmjs.com/package/body-parser) library. If no value is provided, the library uses default `'100kb'`.
 - **Required:** No.
 - **Default:** `none`
 

--- a/packages/node-fhir-server-core/src/server/server.js
+++ b/packages/node-fhir-server-core/src/server/server.js
@@ -144,8 +144,18 @@ class Server {
     // Add compression
     this.app.use(compression({ level: 9 }));
     // Enable the body parser
-    this.app.use(bodyParser.urlencoded({ extended: true }));
-    this.app.use(bodyParser.json({ type: ['application/fhir+json', 'application/json+fhir'] }));
+    this.app.use(
+      bodyParser.urlencoded({
+        extended: true,
+        limit: this.config.server.requestSizeLimit,
+      })
+    );
+    this.app.use(
+      bodyParser.json({
+        type: ['application/fhir+json', 'application/json+fhir'],
+        limit: this.config.server.requestSizeLimit,
+      })
+    );
     // Enable @hapi/bourne to protect against prototype injection
     this.app.use(prototypeInjectionHandler);
     // Set favicon


### PR DESCRIPTION
This change will add the ability to specify maximum request body size.

Reason:
The FHIR type [Attachment](http://hl7.org/fhir/R4/datatypes.html#Attachment) allows to transfer data as base64 string. However, request body size limit is currently not specified, so default 100kb from body-parser library is used. If the data is larger, request fails with the following error: "Unexpected: request entity too large"
