### PR TITLE
Asymmetrik to BlueHalo Naming Updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-# Core team members for FHIR at Asymmetrik
+# Core team members for FHIR at BlueHalo
 
 * @Robert-W @jonterrylee @zeevosec @luan-dev

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,4 +8,4 @@
 
 **What are the steps to reproduce?**
 
-**What OS are you using and what version of node.js and @asymmetrik/node-fhir-server-core are you running?**
+**What OS are you using and what version of node.js and @bluehalo/node-fhir-server-core are you running?**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First off, Contributions are always welcome and we appreciate any help you can o
 
 ## Before you begin
 
-Below are some general guidelines we try to stick to on all of our FHIR related repositories. When contributing to `@asymmetrik/node-fhir-server-core`, we do ask that you do your best to follow these guidelines.
+Below are some general guidelines we try to stick to on all of our FHIR related repositories. When contributing to `@bluehalo/node-fhir-server-core`, we do ask that you do your best to follow these guidelines.
 
 ### Branch Organization
 
@@ -80,8 +80,8 @@ When cutting a release, the following steps need to be performed.
 
 ## Resources
 
-For more information about how things are designed and how they work, please consult our [wiki](https://github.com/Asymmetrik/node-fhir-server-core/wiki).
+For more information about how things are designed and how they work, please consult our [wiki](https://github.com/bluehalo/node-fhir-server-core/wiki).
 
 ## Issues
 
-Please file your issues [here](https://github.com/Asymmetrik/node-fhir-server-core/issues) and try to provide as much information in the template as possible/relevant.
+Please file your issues [here](https://github.com/bluehalo/node-fhir-server-core/issues) and try to provide as much information in the template as possible/relevant.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Asymmetrik FHIR API Server
+# BlueHalo FHIR API Server
 
-> A Secure Rest implementation for the [HL7 FHIR Specification](https://www.hl7.org/fhir/). For API documentation, please see [our documents](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/docs).
+> A Secure Rest implementation for the [HL7 FHIR Specification](https://www.hl7.org/fhir/). For API documentation, please see [our documents](https://github.com/bluehalo/node-fhir-server-core/tree/master/docs).
 
-[![Build Status](https://travis-ci.org/Asymmetrik/node-fhir-server-core.svg?branch=develop)](https://travis-ci.org/Asymmetrik/node-fhir-server-core) [![Known Vulnerabilities](https://snyk.io/test/github/asymmetrik/node-fhir-server-core/badge.svg?targetFile=package.json)](https://snyk.io/test/github/asymmetrik/node-fhir-server-core?targetFile=package.json)
+[![Build Status](https://travis-ci.org/bluehalo/node-fhir-server-core.svg?branch=develop)](https://travis-ci.org/bluehalo/node-fhir-server-core) [![Known Vulnerabilities](https://snyk.io/test/github/bluehalo/node-fhir-server-core/badge.svg?targetFile=package.json)](https://snyk.io/test/github/bluehalo/node-fhir-server-core?targetFile=package.json)
 
-The Asymmetrik Extensible Server Framework for Healthcare allows organizations to build secure, interoperable solutions that can aggregate and expose healthcare resources via a common HL7® FHIR®-compatible REST API. This server framework currently supports **DSTU2** (1.0.2), **STU3** (3.0.1), and **R4** (4.0.0) simultaneously. You can decide to support all three or just one by editing the configuration.
+The BlueHalo Extensible Server Framework for Healthcare allows organizations to build secure, interoperable solutions that can aggregate and expose healthcare resources via a common HL7® FHIR®-compatible REST API. This server framework currently supports **DSTU2** (1.0.2), **STU3** (3.0.1), and **R4** (4.0.0) simultaneously. You can decide to support all three or just one by editing the configuration.
 
 The framework defines a core server, `node-fhir-server-core`, a simple, secure Node.js module built according to the FHIR specification and compliant with the [US Core](http://www.hl7.org/fhir/us/core/) implementation.
 
-For an example implementation using MongoDB, please refer to our Github repository that we used for the ONC FHIR Secure API Server Showdown Challenge: [https://github.com/Asymmetrik/node-fhir-server-mongo](https://github.com/Asymmetrik/node-fhir-server-mongo).
+For an example implementation using MongoDB, please refer to our Github repository that we used for the ONC FHIR Secure API Server Showdown Challenge: [https://github.com/bluehalo/node-fhir-server-mongo](https://github.com/bluehalo/node-fhir-server-mongo).
 
 <img src="https://www.asymmetrik.com/wp-content/uploads/2018/01/FHIR-Server-Architecture_Update.png" width="800">
 
 ## node-fhir-server-core@2.0.0
 
-Please view the [Migration Guide](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/docs/MIGRATION_2.0.0.md) for version `2.0.0`. We **will absolutely** continue supporting previous versions but **will prioritize** new features going to `2.0.0` unless we receive requests to retrofit them to older versions.
+Please view the [Migration Guide](https://github.com/bluehalo/node-fhir-server-core/blob/master/docs/MIGRATION_2.0.0.md) for version `2.0.0`. We **will absolutely** continue supporting previous versions but **will prioritize** new features going to `2.0.0` unless we receive requests to retrofit them to older versions.
 
 ## Prerequisites
 
@@ -37,15 +37,15 @@ Please see our [Getting Started](./docs/GettingStarted.md) guide for a walkthrou
 
 Our project vision is to build an easy to use FHIR server that supports all resource profiles defined in the [US Core implementation guide](http://www.hl7.org/fhir/us/core/) and is built with security in mind from the ground up. We decided to use a plugin style architecture so implementors could focus on writing queries and not worry about all the other technical difficulties of securing the server. As this project matures, we plan to support more resources, custom extensions, versions, write capabilities, etc.
 
-We believe in establishing a robust security, especially when it comes to health information. Part of the ONC Secure API Server Challenge was to stand up a server and let penetration testers have a go at it (you can see their results [here](https://github.com/Asymmetrik/node-fhir-server-core/issues?utf8=%E2%9C%93&q=label%3A%22ONC+FHIR+Challenge+Vulnerability%22+)). We are committed to continuing this practice and we will continue fixing any vulnerabilities discovered so we can do our best to make this server as secure as possible. For authentication, we are actively working on methods for simplifying integration with [SMART on FHIR](http://docs.smarthealthit.org/).
+We believe in establishing a robust security, especially when it comes to health information. Part of the ONC Secure API Server Challenge was to stand up a server and let penetration testers have a go at it (you can see their results [here](https://github.com/bluehalo/node-fhir-server-core/issues?utf8=%E2%9C%93&q=label%3A%22ONC+FHIR+Challenge+Vulnerability%22+)). We are committed to continuing this practice and we will continue fixing any vulnerabilities discovered so we can do our best to make this server as secure as possible. For authentication, we are actively working on methods for simplifying integration with [SMART on FHIR](http://docs.smarthealthit.org/).
 
 ## Contributing
 
-Please see [CONTRIBUTING.md](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/CONTRIBUTING.md) for more details regarding contributing issues or code.
+Please see [CONTRIBUTING.md](https://github.com/bluehalo/node-fhir-server-core/blob/master/CONTRIBUTING.md) for more details regarding contributing issues or code.
 
 ## Questions
 
-If you are experiencing a bug, please feel free to file an [issue](https://github.com/Asymmetrik/node-fhir-server-core/issues). For general questions, please post them to [StackOverflow](https://stackoverflow.com/) with the tag `node-fhir-server-core` or `javascript-fhir`.
+If you are experiencing a bug, please feel free to file an [issue](https://github.com/bluehalo/node-fhir-server-core/issues). For general questions, please post them to [StackOverflow](https://stackoverflow.com/) with the tag `node-fhir-server-core` or `javascript-fhir`.
 
 ## Attention
 
@@ -53,4 +53,4 @@ This library makes use of node's path module. This is potentially exploitable in
 
 ## License
 
-`@asymmetrik/node-fhir-server-core` is [MIT licensed](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/LICENSE).
+`@bluehalo/node-fhir-server-core` is [MIT licensed](https://github.com/bluehalo/node-fhir-server-core/blob/master/LICENSE).

--- a/docs/AccessControl.md
+++ b/docs/AccessControl.md
@@ -13,7 +13,7 @@ We have built-in support if you are using [SMART on FHIR](http://docs.smarthealt
 When setting up your FHIR server, add the following config entries to your current configuration:
 
 ```javascript
-const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const FHIRServer = require('@bluehalo/node-fhir-server-core');
 
 let server = FHIRServer.initialize({
   auth: {
@@ -34,10 +34,10 @@ And that is all that is needed as far as config goes, but let's take a look at h
 
 #### Step Two: Define a service
 
-If you are not familiar with writing passport strategies, you can use [`@asymmetrik/sof-strategy`](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages/sof-strategy). To use this, create a file that looks like this:
+If you are not familiar with writing passport strategies, you can use [`@bluehalo/sof-strategy`](https://github.com/bluehalo/node-fhir-server-core/tree/master/packages/sof-strategy). To use this, create a file that looks like this:
 
 ```javascript
-const smartBearerStrategy = require('@asymmetrik/sof-strategy');
+const smartBearerStrategy = require('@bluehalo/sof-strategy');
 
 module.exports.strategy = smartBearerStrategy({
   introspectionUrl: process.env.INTROSPECTION_URL,
@@ -46,10 +46,10 @@ module.exports.strategy = smartBearerStrategy({
 });
 ```
 
-You will also need to add `@asymmetrik/sof-strategy` as a dependency by running:
+You will also need to add `@bluehalo/sof-strategy` as a dependency by running:
 
 ```shell
-yarn add @asymmetrik/sof-strategy
+yarn add @bluehalo/sof-strategy
 ```
 
 And define these environment variables: `INTROSPECTION_URL`, `CLIENT_ID`, and `CLIENT_SECRET`.
@@ -102,7 +102,7 @@ There are also more advanced ways to set up the server. By default, if you do no
 In our [Getting Started](GettingStarted.md) section, we showed you how to create a FHIR server by calling `initialize` and giving it some config, like so:
 
 ```javascript
-const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const FHIRServer = require('@bluehalo/node-fhir-server-core');
 
 let server = FHIRServer.initialize({ ...someConfig });
 ```
@@ -110,7 +110,7 @@ let server = FHIRServer.initialize({ ...someConfig });
 What initialize is actually doing is just calling several internal methods. You can replicate the initialize method by doing the following:
 
 ```javascript
-const { Server } = require('@asymmetrik/node-fhir-server-core');
+const { Server } = require('@bluehalo/node-fhir-server-core');
 
 let server = new Server(config)
   .configureMiddleware()
@@ -127,7 +127,7 @@ let server = new Server(config)
 You can `initialize` a server with your own express app if you need further customization.
 
 ```javascript
-const { initialize, loggers, constants } = require('@asymmetrik/node-fhir-server-core');
+const { initialize, loggers, constants } = require('@bluehalo/node-fhir-server-core');
 const express = require('express');
 
 let config = {};

--- a/docs/ConfiguringProfiles.md
+++ b/docs/ConfiguringProfiles.md
@@ -16,7 +16,7 @@ A [profile](https://www.hl7.org/fhir/profilelist.html) corresponds to a queryabl
 
 ### Supported Profiles
 
-To find a list of all supported profiles, please go to [src/server/resources/base_version/parameters](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages/node-fhir-server-core/src/server/resources/4_0_0/parameters) for your corresponding FHIR version (this links to version `4.0.0`).
+To find a list of all supported profiles, please go to [src/server/resources/base_version/parameters](https://github.com/bluehalo/node-fhir-server-core/tree/master/packages/node-fhir-server-core/src/server/resources/4_0_0/parameters) for your corresponding FHIR version (this links to version `4.0.0`).
 
 Profiles have the following configuration options:
 
@@ -30,14 +30,14 @@ Profiles have the following configuration options:
 #### `versions`
 
 - **Type:** `Array<string>`
-- **Description:** An array of strings containing the versions you intend to support. You cannot add anything you want here, only valid versions supported in core will be used. See [`exports.VERSIONS`](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/packages/node-fhir-server-core/src/constants.js) in the constants file.
+- **Description:** An array of strings containing the versions you intend to support. You cannot add anything you want here, only valid versions supported in core will be used. See [`exports.VERSIONS`](https://github.com/bluehalo/node-fhir-server-core/blob/master/packages/node-fhir-server-core/src/constants.js) in the constants file.
 - **Required:** `Yes`
 - **Default:** `none`
 
 #### `corsOptions`
 
 - **Type:** `object`
-- **Description:** Set profile specific cors options. These will override the default `corsOptions` set in the server config. Please see [https://github.com/expressjs/cors#configuration-options](https://github.com/expressjs/cors#configuration-options) for details. The `methods` configuration will not be honored if specified here. This is controlled by `@asymmetrik/node-fhir-server-core` and cannot be overridden.
+- **Description:** Set profile specific cors options. These will override the default `corsOptions` set in the server config. Please see [https://github.com/expressjs/cors#configuration-options](https://github.com/expressjs/cors#configuration-options) for details. The `methods` configuration will not be honored if specified here. This is controlled by `@bluehalo/node-fhir-server-core` and cannot be overridden.
 - **Required:** `No`
 - **Default:** `none`
 
@@ -51,7 +51,7 @@ Each profile has a pre-defined set of methods it can implement. If you do not wa
 **NOTE** - We used to pass the logger in as an argument. We have made several changes to loggers in general to make them more flexible and less annoying to pass around. You now need to load them yourselves from the core library. You also need to load the schemas and return the objects explicitly as we no longer do the casting ourselves. A service will commonly at least have the following setup:
 
 ```javascript
-const { loggers, resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { loggers, resolveSchema } = require('@bluehalo/node-fhir-server-core');
 const logger = loggers.get('default');
 ```
 
@@ -69,7 +69,7 @@ const logger = loggers.get('default');
 - **Example:**
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.search = async (args, context) => {
   let BundleEntry = resolveSchema(args.base_version, 'bundleentry');
@@ -93,7 +93,7 @@ module.exports.search = async (args, context) => {
 - **Example:**
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.searchById = async (args, context) => {
   let Patient = resolveSchema(args.base_version, 'patient');
@@ -111,7 +111,7 @@ module.exports.searchById = async (args, context) => {
 - **Example:**
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.searchByVersionId = async (args, context) => {
   let Patient = resolveSchema(args.base_version, 'patient');
@@ -129,7 +129,7 @@ module.exports.searchByVersionId = async (args, context) => {
 - **Example:**
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.history = async (args, context) => {
   let BundleEntry = resolveSchema(args.base_version, 'bundleentry');
@@ -154,7 +154,7 @@ module.exports.history = async (args, context) => {
 - **Example:**
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.historyById = async (args, context) => {
   let Patient = resolveSchema(args.base_version, 'patient');
@@ -172,7 +172,7 @@ module.exports.historyById = async (args, context) => {
 - **Example:**
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.create = async (args, context) => {
   let Patient = resolveSchema(args.base_version, 'patient');
@@ -196,7 +196,7 @@ module.exports.create = async (args, context) => {
 - **Example:**
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.update = async (args, context) => {
 	let Patient = resolveSchema(args.base_version, 'patient');
@@ -224,7 +224,7 @@ module.exports.update = async (args, context) => {
 - **Example:**
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.patch = async (args, context) => {
 	let Patient = resolveSchema(args.base_version, 'patient');
@@ -255,7 +255,7 @@ module.exports.patch = async (args, context) => {
 - **Example:**
 
 ```javascript
-const { ServerError } = require('@asymmetrik/node-fhir-server-core');
+const { ServerError } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.remove = async (args, context) => {
   try {
@@ -285,4 +285,4 @@ module.exports.remove = async (args, context) => {
 
 ## Arguments
 
-Each resource supports the arguments defined by the specification for its own version. You can either review the official FHIR documentation, or you can look in the [resources](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/packages/node-fhir-server-core/src/server/resources) directory of this project. Each `version` folder represents a version we support, and in each version folder there is a `parameters` folder which defines the parameters for each resource. When an API endpoint is hit, each resource will allow its own arguments and any inherited arguments from parent resources.
+Each resource supports the arguments defined by the specification for its own version. You can either review the official FHIR documentation, or you can look in the [resources](https://github.com/bluehalo/node-fhir-server-core/blob/master/packages/node-fhir-server-core/src/server/resources) directory of this project. Each `version` folder represents a version we support, and in each version folder there is a `parameters` folder which defines the parameters for each resource. When an API endpoint is hit, each resource will allow its own arguments and any inherited arguments from parent resources.

--- a/docs/CustomCapability.md
+++ b/docs/CustomCapability.md
@@ -6,13 +6,13 @@ The capability statement now allows for the configuration of what information ge
 
 ### Creating a Statement Generator
 
-You can include this code where you define your Asymmetrik Server configurations or include it in another file and require it in. For this example, we will go with the latter option.
+You can include this code where you define your BlueHalo Server configurations or include it in another file and require it in. For this example, we will go with the latter option.
 
-First, we're going to require the Asymmetrik FHIR Server source code. This will allow us to have access to the class that is responsible for generating the Capability Statement so that we can create our own.
+First, we're going to require the BlueHalo FHIR Server source code. This will allow us to have access to the class that is responsible for generating the Capability Statement so that we can create our own.
 
 ```javascript
-// require the Asymmetrik FHIR Server
-const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+// require the BlueHalo FHIR Server
+const FHIRServer = require('@bluehalo/node-fhir-server-core');
 ```
 
 Then we'll create a function that will require the `CapabilityStatement` class, and return a new instance that contains your information. Please make sure you remain compliant with the FHIR specification.
@@ -47,7 +47,7 @@ let customCapabilityStatement = (resources) => {
 
 Next, we're going to create a custom Security Statement. This is separate from the Capability Statement. It provides information about the security of the current implementation.
 If provided, this will be derived from the information you pass to the 'security' property from the FHIR Server Config.
-The below Security Statement is the default one provided by Asymmetrik, but can be customized to fit your needs.
+The below Security Statement is the default one provided by BlueHalo, but can be customized to fit your needs.
 
 ```javascript
 /**
@@ -102,7 +102,7 @@ module.exports.generateStatements = (args) => {
 Now that we've built out our Statement Generator and have customized the Capability Statement info to our liking, we can add it to our configuration by doing the following:
 
 ```javascript
-const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const FHIRServer = require('@bluehalo/node-fhir-server-core');
 const generateCapabilityStatement = require('path to your statement generator file').generateStatements; // require the statement generator file
 
 let config = {

--- a/docs/CustomMetadata.md
+++ b/docs/CustomMetadata.md
@@ -46,7 +46,7 @@ module.exports = {
 With this code we say that only "identifier" and "birthdate" are implemented as search parameters for patients.
 Each search parameter must be defined and added to the searchParam list.
 
-All available parameters for the variable can be found at the following place `node_modules/@asymmetrik/node-fhir-server-core/src/server/resources/4_0_0/parameters/patient.parameters.js`
+All available parameters for the variable can be found at the following place `node_modules/@bluehalo/node-fhir-server-core/src/server/resources/4_0_0/parameters/patient.parameters.js`
 
 ### Updating profiles
 

--- a/docs/CustomizeLogging.md
+++ b/docs/CustomizeLogging.md
@@ -1,11 +1,11 @@
 ## Overview
 
-If you simply need to use the core fhir server `winston` Container you can do so by requiring it from `@asymmetrik/fhir-server-core`
+If you simply need to use the core fhir server `winston` Container you can do so by requiring it from `@bluehalo/fhir-server-core`
 
 ```javascript
 // Your patient.service.js
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
-const { loggers } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
+const { loggers } = require('@bluehalo/node-fhir-server-core');
 const logger = loggers.get('default');
 
 module.exports.search = async (args, context) => {
@@ -36,7 +36,7 @@ You can access the core `winston` Transports manually using `Server.configureLog
 
 ```javascript
 // Example server with write to file logging
-const { initialize } = require('@asymmetrik/node-fhir-server-core');
+const { initialize } = require('@bluehalo/node-fhir-server-core');
 
 const fhirServerConfig = {
   profiles: {

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -35,7 +35,7 @@ fhir-server
 Next, run:
 
 ```shell
-yarn add @asymmetrik/node-fhir-server-core
+yarn add @bluehalo/node-fhir-server-core
 ```
 
 ### Create an entry file and a start script
@@ -43,7 +43,7 @@ yarn add @asymmetrik/node-fhir-server-core
 Let's start by creating an `index.js` file in the root of the project and add the following code to it:
 
 ```javascript
-const { initialize, loggers, constants } = require('@asymmetrik/node-fhir-server-core');
+const { initialize, loggers, constants } = require('@bluehalo/node-fhir-server-core');
 
 let config = {};
 let server = initialize(config);
@@ -80,7 +80,7 @@ The next thing we want to do is run this file in node. Let's add a script to our
     "start": "node index.js"
   },
   "dependencies": {
-    "@asymmetrik/node-fhir-server-core": "^1.3.0"
+    "@bluehalo/node-fhir-server-core": "^1.3.0"
   }
 }
 ```
@@ -93,7 +93,7 @@ yarn start
 
 If you have done everything correctly so far, you will receive the following error.
 
-> Error: No profiles configured. We do not enable any profiles by default so please review the profile wiki for how to enable profiles and capabilities. See https://github.com/Asymmetrik/node-fhir-server-core/blob/master/docs/ConfiguringProfiles.md.
+> Error: No profiles configured. We do not enable any profiles by default so please review the profile wiki for how to enable profiles and capabilities. See https://github.com/BlueHalo/node-fhir-server-core/blob/master/docs/ConfiguringProfiles.md.
 
 By default, our library does not configure any profiles. Without a profile, what is the point of having a server? Next, let's walk you through setting up a simple patient profile. A profile corresponds to a queryable FHIR resource, and we support all the standard searchable resources.
 
@@ -127,7 +127,7 @@ The next thing we need to do is update our config in `index.js` to tell it we wa
 In `index.js`, add the following to the top of the file:
 
 ```javascript
-const { initialize, loggers, constants } = require('@asymmetrik/node-fhir-server-core');
+const { initialize, loggers, constants } = require('@bluehalo/node-fhir-server-core');
 const { VERSIONS } = constants;
 ```
 
@@ -173,4 +173,4 @@ Open [http://localhost:3000/4_0_0/metadata](http://localhost:3000/4_0_0/metadata
 
 This is good as this is the error we created in the `patient.service.js`. `patient.service.js` is where you want to execute your queries and return your patient JSON. So you may need to connect to a database, query your data, and possibly even map your data back to a FHIR format if it is not already in a FHIR format.
 
-If you made it this far, thanks for sticking it out and completing the Getting Started guide. Please browse the other [documentation pages](../docs) for more information and feel free to file issues/questions on our [issues](https://github.com/Asymmetrik/node-fhir-server-core/issues) page.
+If you made it this far, thanks for sticking it out and completing the Getting Started guide. Please browse the other [documentation pages](../docs) for more information and feel free to file issues/questions on our [issues](https://github.com/BlueHalo/node-fhir-server-core/issues) page.

--- a/docs/MIGRATION_2.0.0.md
+++ b/docs/MIGRATION_2.0.0.md
@@ -1,6 +1,6 @@
 # Migrating to Version 2.0.0
 
-This guide represents all the known changes that will need your attention when migrating to version `2.0.0`. If we are missing anything, please open an issue so we can update this guide for the benefit of everyone. Before we continue, I would like to talk about why we are making these changes. We think opinions are good, but too many can be bad. We had a lot of logic in the code that made customizing things difficult or impossible, and also made the source code a pain to work with. We recently started moving things to separate packages, [packages](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages), and have been making the code that we generate leaner and leaner.
+This guide represents all the known changes that will need your attention when migrating to version `2.0.0`. If we are missing anything, please open an issue so we can update this guide for the benefit of everyone. Before we continue, I would like to talk about why we are making these changes. We think opinions are good, but too many can be bad. We had a lot of logic in the code that made customizing things difficult or impossible, and also made the source code a pain to work with. We recently started moving things to separate packages, [packages](https://github.com/BlueHalo/node-fhir-server-core/tree/master/packages), and have been making the code that we generate leaner and leaner.
 
 We think this will simplify things a lot for developers on both sides, contributors and users alike. We also plan to maintain the older versions and even do bug fixes. However, newer features are going to be prioritized on version `2.0.0` and only retrofit to older branches when requested.
 
@@ -29,14 +29,14 @@ We think this will simplify things a lot for developers on both sides, contribut
 
 ### Return types
 
-One major change for version `2.0.0` is how your services returned resources. Everything before `2.0.0` returned JSON and only JSON. Bundles would attempt to set correct properties based on a variety of things, but ultimately, would not cast resources because it did not want to assume all resources were the same type. Doing the casting and crafting these responses made the response utils very ugly and they were doing more than they really needed to do. Response utils have since moved to an external package, which you can find at [fhir-response-util](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages/fhir-response-util). They are now very simple to work with and easier to modify in the future.
+One major change for version `2.0.0` is how your services returned resources. Everything before `2.0.0` returned JSON and only JSON. Bundles would attempt to set correct properties based on a variety of things, but ultimately, would not cast resources because it did not want to assume all resources were the same type. Doing the casting and crafting these responses made the response utils very ugly and they were doing more than they really needed to do. Response utils have since moved to an external package, which you can find at [fhir-response-util](https://github.com/BlueHalo/node-fhir-server-core/tree/master/packages/fhir-response-util). They are now very simple to work with and easier to modify in the future.
 
 What this means for developers is that they will now need to be explicit when returning data from a service and use the schemas we are providing.
 
 Here is an example that searches for multiple resources:
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service, this returns a bundle
 module.exports.search = async (args, context) => {
   let BundleEntry = resolveSchema(args.base_version, 'bundleentry');
@@ -64,7 +64,7 @@ module.exports.search = async (args, context) => {
 And here is another example that searches by id:
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // In patient service, this returns a bundle
 module.exports.searchById = async (args, context) => {
   let Patient = resolveSchema(args.base_version, 'patient');
@@ -82,7 +82,7 @@ In version `2.0.0`, we changed how you return data in your services, so now you 
 For example, let's throw an error for attempting to delete a resource that other resources depend on. The spec says the HTTP status code must be a 409 in this case, for conflict. You could implement that like so:
 
 ```javascript
-const { ServerError } = require('@asymmetrik/node-fhir-server-core');
+const { ServerError } = require('@bluehalo/node-fhir-server-core');
 // In patient service
 module.exports.remove = async (args, context) => {
   try {
@@ -125,7 +125,7 @@ module.exports.search = (args, contexts, logger) =>
 Or seeing it attached to the server object, like this:
 
 ```javascript
-const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const FHIRServer = require('@bluehalo/node-fhir-server-core');
 
 let config = { ... };
 let server = FHIRServer.initialize(config);
@@ -146,14 +146,14 @@ The new way to use the logger is to require it and invoke `get` on the loggers c
 To get the logger anywhere in your code, just add the following:
 
 ```javascript
-const { loggers } = require('@asymmetrik/node-fhir-server-core');
+const { loggers } = require('@bluehalo/node-fhir-server-core');
 const logger = loggers.get('default');
 ```
 
 If you want to access the winston container, you can do the following:
 
 ```javascript
-const { container } = require('@asymmetrik/node-fhir-server-core').loggers;
+const { container } = require('@bluehalo/node-fhir-server-core').loggers;
 const logger = container.get('default');
 ```
 
@@ -162,7 +162,7 @@ You can read more on the Container API here, https://github.com/winstonjs/winsto
 A common change will be to update your service to look like this now:
 
 ```javascript
-const { loggers } = require('@asymmetrik/node-fhir-server-core');
+const { loggers } = require('@bluehalo/node-fhir-server-core');
 const logger = loggers.get('default');
 // In a patient service for example, with async
 module.exports.search = async (args, context) => {
@@ -178,7 +178,7 @@ module.exports.update = (args, context) =>
 and for your server startup:
 
 ```javascript
-const { initialize, loggers } = require('@asymmetrik/node-fhir-server-core');
+const { initialize, loggers } = require('@bluehalo/node-fhir-server-core');
 const logger = loggers.get('default');
 
 let config = { ... };
@@ -201,14 +201,14 @@ server.listen(3000, () => {
 - **Example:**
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema } = require('@bluehalo/node-fhir-server-core');
 // Load R4 Operation Outcome
 let OperationOutcome = resolveSchema('4_0_0', 'operationoutcome');
 // Load STU3 Patient class
 let Patient = resolveSchema('3_0_1', 'patient');
 ```
 
-Allowed values can be found in the [resources](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/packages/node-fhir-server-core/src/server/resources) directory. Each top level folder represents a version and inside each version folder is a schemas directory which contains all the available schemas you can load.
+Allowed values can be found in the [resources](https://github.com/BlueHalo/node-fhir-server-core/blob/master/packages/node-fhir-server-core/src/server/resources) directory. Each top level folder represents a version and inside each version folder is a schemas directory which contains all the available schemas you can load.
 
 ### Logging Container
 
@@ -223,17 +223,17 @@ Please check out the following links for more info:
 Again, you can access these like so:
 
 ```javascript
-const { loggers } = require('@asymmetrik/node-fhir-server-core');
+const { loggers } = require('@bluehalo/node-fhir-server-core');
 const logger = loggers.get('default');
 
 // Or with the container, this will still get the same default logger
-const { container } = require('@asymmetrik/node-fhir-server-core').loggers;
+const { container } = require('@bluehalo/node-fhir-server-core').loggers;
 const logger = container.get('default');
 ```
 
 ### Tools Migration
 
-More and more logic is being removed and developed in separate tools. They are all inside a monorepo that is managed by Lerna. This makes it easier to have better unit testing and upgrades. We can just apply patches there and publish versions independently of the core library. All packages are available here: https://github.com/Asymmetrik/node-fhir-server-core. (Previously located here: https://github.com/Asymmetrik/phx-tools.) Some are GraphQL specific but the majority are not. We have response utils, Smart on FHIR scope utils, passport strategies, query builders, and parameter sanitization logic.
+More and more logic is being removed and developed in separate tools. They are all inside a monorepo that is managed by Lerna. This makes it easier to have better unit testing and upgrades. We can just apply patches there and publish versions independently of the core library. All packages are available here: https://github.com/BlueHalo/node-fhir-server-core. (Previously located here: https://github.com/BlueHalo/phx-tools.) Some are GraphQL specific but the majority are not. We have response utils, Smart on FHIR scope utils, passport strategies, query builders, and parameter sanitization logic.
 
 ### Favicon
 

--- a/docs/ServerConfiguration.md
+++ b/docs/ServerConfiguration.md
@@ -141,7 +141,7 @@ Here is an example config with all the currently supported options. See descript
 #### `server.corsOptions`
 
 - **Type:** `object`
-- **Description:** Any default cors options you would like applied to all routes. Please see [https://github.com/expressjs/cors#configuration-options](https://github.com/expressjs/cors#configuration-options) for details. The `methods` configuration will not be honored if specified here. That is the only option controlled by `@asymmetrik/node-fhir-server-core` and cannot be overridden.
+- **Description:** Any default cors options you would like applied to all routes. Please see [https://github.com/expressjs/cors#configuration-options](https://github.com/expressjs/cors#configuration-options) for details. The `methods` configuration will not be honored if specified here. That is the only option controlled by `@bluehalo/node-fhir-server-core` and cannot be overridden.
 - **Required:** No
 - **Default:** `none`
 
@@ -176,14 +176,14 @@ const fhirConfig = {
 #### `server.ssl.key`
 
 - **Type:** `string`
-- **Description:** Path to your private key. See [Contributor's guide](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/CONTRIBUTING.md#optional) for how to generate a self-signed cert for local development.
+- **Description:** Path to your private key. See [Contributor's guide](https://github.com/BlueHalo/node-fhir-server-core/blob/master/CONTRIBUTING.md#optional) for how to generate a self-signed cert for local development.
 - **Required:** No. If you want to setup express to use ssl, you need both a key and cert.
 - **Default:** `none`
 
 #### `server.ssl.cert`
 
 - **Type:** `string`
-- **Description:** Path to your certificate. See [Contributor's guide](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/CONTRIBUTING.md#optional) for how to generate a self-signed cert for local development.
+- **Description:** Path to your certificate. See [Contributor's guide](https://github.com/BlueHalo/node-fhir-server-core/blob/master/CONTRIBUTING.md#optional) for how to generate a self-signed cert for local development.
 - **Required:** No. If you want to setup express to use ssl, you need both a key and cert.
 - **Default:** `none`
 

--- a/package.json
+++ b/package.json
@@ -3,16 +3,16 @@
   "private": true,
   "version": "2.0.11",
   "description": "Node FHIR Rest API Server and surrounding ecosystem",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core#readme",
+  "homepage": "https://github.com/bluehalo/node-fhir-server-core#readme",
   "bugs": {
-    "url": "https://github.com/Asymmetrik/node-fhir-server-core/issues"
+    "url": "https://github.com/bluehalo/node-fhir-server-core/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Asymmetrik/node-fhir-server-core.git"
+    "url": "git+https://github.com/bluehalo/node-fhir-server-core.git"
   },
   "license": "MIT",
-  "author": "Asymmetrik Ltd.",
+  "author": "BlueHalo",
   "contributors": [
     "Robert Winterbottom <rwinterbottom@asymmetrik.com>",
     "Jon Lee <jlee@asymmetrik.com>",

--- a/packages/fhir-gql-schema-utils/CHANGELOG.md
+++ b/packages/fhir-gql-schema-utils/CHANGELOG.md
@@ -3,25 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.1.5](https://github.com/Asymmetrik/node-fhir-server-core/compare/@asymmetrik/sof-graphql-invariant@1.1.4...@asymmetrik/sof-graphql-invariant@1.1.5) (2021-09-16)
+## [1.1.5](https://github.com/BlueHalo/node-fhir-server-core/compare/@bluehalo/sof-graphql-invariant@1.1.4...@bluehalo/sof-graphql-invariant@1.1.5) (2021-09-16)
 
 ### Update Dependency
 
 - Update graphql to 15.6.0
 
-## [1.1.1](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-gql-schema-utils@1.0.2...@asymmetrik/fhir-gql-schema-utils@1.1.1) (2019-04-05)
+## [1.1.1](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-gql-schema-utils@1.0.2...@bluehalo/fhir-gql-schema-utils@1.1.1) (2019-04-05)
 
-**Note:** Version bump only for package @asymmetrik/fhir-gql-schema-utils
+**Note:** Version bump only for package @bluehalo/fhir-gql-schema-utils
 
-# [1.1.0](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-gql-schema-utils@1.0.2...@asymmetrik/fhir-gql-schema-utils@1.1.0) (2019-03-20)
+# [1.1.0](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-gql-schema-utils@1.0.2...@bluehalo/fhir-gql-schema-utils@1.1.0) (2019-03-20)
 
 ### Features
 
-- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/Asymmetrik/phx-tools/commit/fefce17))
-- added lockfiles for each package ([f8d9a31](https://github.com/Asymmetrik/phx-tools/commit/f8d9a31))
+- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/BlueHalo/phx-tools/commit/fefce17))
+- added lockfiles for each package ([f8d9a31](https://github.com/BlueHalo/phx-tools/commit/f8d9a31))
 
-## [1.0.2](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-gql-schema-utils@1.0.1...@asymmetrik/fhir-gql-schema-utils@1.0.2) (2019-02-13)
+## [1.0.2](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-gql-schema-utils@1.0.1...@bluehalo/fhir-gql-schema-utils@1.0.2) (2019-02-13)
 
 ### Bug Fixes
 
-- Fixed paths on repository url and homepage ([#9](https://github.com/Asymmetrik/phx-tools/issues/9)) ([d662ec8](https://github.com/Asymmetrik/phx-tools/commit/d662ec8))
+- Fixed paths on repository url and homepage ([#9](https://github.com/BlueHalo/phx-tools/issues/9)) ([d662ec8](https://github.com/BlueHalo/phx-tools/commit/d662ec8))

--- a/packages/fhir-gql-schema-utils/README.md
+++ b/packages/fhir-gql-schema-utils/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```shell
-yarn add @asymmetrik/fhir-gql-schema-utils
+yarn add @bluehalo/fhir-gql-schema-utils
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ GraphQLObjectType's into a single set of fields. Essentially allowing you to
 extend other schemas more easily.
 
 ```javascript
-const { extendSchema } = require(' @asymmetrik/fhir-gql-schema-utils');
+const { extendSchema } = require(' @bluehalo/fhir-gql-schema-utils');
 
 // Create a schema and merge in other schemas or JSON objects
 // to include fields in a schema
@@ -36,11 +36,11 @@ let FooSchema = new GraphQLObjectType({
 // and AnotherSchema have.
 ```
 
-See [fhir-gql-schema-utils tests](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages/fhir-gql-schema-utils/index.test.js) for more usage examples.
+See [fhir-gql-schema-utils tests](https://github.com/BlueHalo/node-fhir-server-core/tree/master/packages/fhir-gql-schema-utils/index.test.js) for more usage examples.
 
 ## Arguments
 
-`@asymmetrik/fhir-gql-schema-utils` currently only contains the one utility. We will be adding more over time but for now you can only use `extendSchema`.
+`@bluehalo/fhir-gql-schema-utils` currently only contains the one utility. We will be adding more over time but for now you can only use `extendSchema`.
 
 ### extendSchema
 

--- a/packages/fhir-gql-schema-utils/package.json
+++ b/packages/fhir-gql-schema-utils/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/fhir-gql-schema-utils",
+  "name": "@bluehalo/fhir-gql-schema-utils",
   "version": "1.1.5",
   "description": "Suite of FHIR related utilities for GraphQL schemas.",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/fhir-gql-schema-utils"

--- a/packages/fhir-json-schema-validator/CHANGELOG.md
+++ b/packages/fhir-json-schema-validator/CHANGELOG.md
@@ -5,4 +5,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 0.9.1 (2019-05-16)
 
-**Note:** Version bump only for package @asymmetrik/fhir-json-schema-validator
+**Note:** Version bump only for package @bluehalo/fhir-json-schema-validator

--- a/packages/fhir-json-schema-validator/README.md
+++ b/packages/fhir-json-schema-validator/README.md
@@ -5,12 +5,12 @@
 ## Install
 
 ```shell
-yarn add @asymmetrik/fhir-json-schema-validator
+yarn add @bluehalo/fhir-json-schema-validator
 ```
 
 ## Arguments
 
-`@asymmetrik/fhir-json-schema-validator` exports a single class called JSONSchemaValidator. This class takes two optional
+`@bluehalo/fhir-json-schema-validator` exports a single class called JSONSchemaValidator. This class takes two optional
 arguments for initialization:
 
 > #### `schema`

--- a/packages/fhir-json-schema-validator/package.json
+++ b/packages/fhir-json-schema-validator/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/fhir-json-schema-validator",
+  "name": "@bluehalo/fhir-json-schema-validator",
   "version": "0.9.9",
   "description": "FHIR json schema validator",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/fhir-json-schema-validator"

--- a/packages/fhir-qb-mongo/CHANGELOG.md
+++ b/packages/fhir-qb-mongo/CHANGELOG.md
@@ -3,23 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.11.0](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-qb-mongo@0.10.5...@asymmetrik/fhir-qb-mongo@0.11.0) (2019-11-12)
+# [0.11.0](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-qb-mongo@0.10.5...@bluehalo/fhir-qb-mongo@0.11.0) (2019-11-12)
 
 ### Features
 
-- add token searching for psql ([#32](https://github.com/Asymmetrik/phx-tools/issues/32)) ([b9222d4](https://github.com/Asymmetrik/phx-tools/commit/b9222d4))
+- add token searching for psql ([#32](https://github.com/BlueHalo/phx-tools/issues/32)) ([b9222d4](https://github.com/BlueHalo/phx-tools/commit/b9222d4))
 
-## [0.10.2](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-qb-mongo@0.10.1...@asymmetrik/fhir-qb-mongo@0.10.2) (2019-05-03)
+## [0.10.2](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-qb-mongo@0.10.1...@bluehalo/fhir-qb-mongo@0.10.2) (2019-05-03)
 
-**Note:** Version bump only for package @asymmetrik/fhir-qb-mongo
+**Note:** Version bump only for package @bluehalo/fhir-qb-mongo
 
 ## 0.10.1 (2019-04-05)
 
-**Note:** Version bump only for package @asymmetrik/fhir-qb-mongo
+**Note:** Version bump only for package @bluehalo/fhir-qb-mongo
 
 # 0.10.0 (2019-03-20)
 
 ### Features
 
-- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/Asymmetrik/phx-tools/commit/fefce17))
-- update fhir-sanitize-params and phx-tools tests ([3466c1b](https://github.com/Asymmetrik/phx-tools/commit/3466c1b))
+- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/BlueHalo/phx-tools/commit/fefce17))
+- update fhir-sanitize-params and phx-tools tests ([3466c1b](https://github.com/BlueHalo/phx-tools/commit/3466c1b))

--- a/packages/fhir-qb-mongo/README.md
+++ b/packages/fhir-qb-mongo/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```shell
-yarn add @asymmetrik/fhir-qb-mongo
+yarn add @bluehalo/fhir-qb-mongo
 ```
 
 ## Usage

--- a/packages/fhir-qb-mongo/package.json
+++ b/packages/fhir-qb-mongo/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/fhir-qb-mongo",
+  "name": "@bluehalo/fhir-qb-mongo",
   "version": "0.12.4",
   "description": "FHIR query builder for Mongo DB",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/fhir-qb-mongo"

--- a/packages/fhir-qb-sql/CHANGELOG.md
+++ b/packages/fhir-qb-sql/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.1.0](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-qb-sql@1.0.1...@asymmetrik/fhir-qb-sql@1.1.0) (2019-11-12)
+# [1.1.0](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-qb-sql@1.0.1...@bluehalo/fhir-qb-sql@1.1.0) (2019-11-12)
 
 ### Features
 
-- add token searching for psql ([#32](https://github.com/Asymmetrik/phx-tools/issues/32)) ([b9222d4](https://github.com/Asymmetrik/phx-tools/commit/b9222d4))
+- add token searching for psql ([#32](https://github.com/BlueHalo/phx-tools/issues/32)) ([b9222d4](https://github.com/BlueHalo/phx-tools/commit/b9222d4))

--- a/packages/fhir-qb-sql/README.md
+++ b/packages/fhir-qb-sql/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```shell
-yarn add @asymmetrik/fhir-qb-sql
+yarn add @bluehalo/fhir-qb-sql
 ```
 
 ## Usage

--- a/packages/fhir-qb-sql/package.json
+++ b/packages/fhir-qb-sql/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/fhir-qb-sql",
+  "name": "@bluehalo/fhir-qb-sql",
   "version": "1.1.6",
   "description": "FHIR query builder for SQL",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/fhir-qb-sql"

--- a/packages/fhir-qb/CHANGELOG.md
+++ b/packages/fhir-qb/CHANGELOG.md
@@ -3,39 +3,39 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.12.0](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-qb@0.11.2...@asymmetrik/fhir-qb@0.12.0) (2019-11-12)
+# [0.12.0](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-qb@0.11.2...@bluehalo/fhir-qb@0.12.0) (2019-11-12)
 
 ### Features
 
-- add token searching for psql ([#32](https://github.com/Asymmetrik/phx-tools/issues/32)) ([b9222d4](https://github.com/Asymmetrik/phx-tools/commit/b9222d4))
+- add token searching for psql ([#32](https://github.com/BlueHalo/phx-tools/issues/32)) ([b9222d4](https://github.com/BlueHalo/phx-tools/commit/b9222d4))
 
-# [0.11.0](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-qb@0.10.4...@asymmetrik/fhir-qb@0.11.0) (2019-06-07)
+# [0.11.0](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-qb@0.10.4...@bluehalo/fhir-qb@0.11.0) (2019-06-07)
 
 ### Bug Fixes
 
-- missing modifier queries were inverted ([#20](https://github.com/Asymmetrik/phx-tools/issues/20)) ([ba6eba7](https://github.com/Asymmetrik/phx-tools/commit/ba6eba7))
+- missing modifier queries were inverted ([#20](https://github.com/BlueHalo/phx-tools/issues/20)) ([ba6eba7](https://github.com/BlueHalo/phx-tools/commit/ba6eba7))
 
 ### Features
 
-- support list of xpaths in search parameter xpath ([#22](https://github.com/Asymmetrik/phx-tools/issues/22)) ([84ccfd6](https://github.com/Asymmetrik/phx-tools/commit/84ccfd6))
+- support list of xpaths in search parameter xpath ([#22](https://github.com/BlueHalo/phx-tools/issues/22)) ([84ccfd6](https://github.com/BlueHalo/phx-tools/commit/84ccfd6))
 
-## [0.10.3](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-qb@0.10.2...@asymmetrik/fhir-qb@0.10.3) (2019-05-16)
+## [0.10.3](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-qb@0.10.2...@bluehalo/fhir-qb@0.10.3) (2019-05-16)
 
-**Note:** Version bump only for package @asymmetrik/fhir-qb
+**Note:** Version bump only for package @bluehalo/fhir-qb
 
-## [0.10.2](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-qb@0.10.1...@asymmetrik/fhir-qb@0.10.2) (2019-05-03)
+## [0.10.2](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-qb@0.10.1...@bluehalo/fhir-qb@0.10.2) (2019-05-03)
 
 ### Bug Fixes
 
-- get params from reqeust object ([#15](https://github.com/Asymmetrik/phx-tools/issues/15)) ([0f71c51](https://github.com/Asymmetrik/phx-tools/commit/0f71c51))
+- get params from reqeust object ([#15](https://github.com/BlueHalo/phx-tools/issues/15)) ([0f71c51](https://github.com/BlueHalo/phx-tools/commit/0f71c51))
 
 ## 0.10.1 (2019-04-05)
 
-**Note:** Version bump only for package @asymmetrik/fhir-qb
+**Note:** Version bump only for package @bluehalo/fhir-qb
 
 # 0.10.0 (2019-03-20)
 
 ### Features
 
-- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/Asymmetrik/phx-tools/commit/fefce17))
-- update fhir-sanitize-params and phx-tools tests ([3466c1b](https://github.com/Asymmetrik/phx-tools/commit/3466c1b))
+- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/BlueHalo/phx-tools/commit/fefce17))
+- update fhir-sanitize-params and phx-tools tests ([3466c1b](https://github.com/BlueHalo/phx-tools/commit/3466c1b))

--- a/packages/fhir-qb/README.md
+++ b/packages/fhir-qb/README.md
@@ -5,16 +5,16 @@
 ## Install
 
 ```shell
-yarn add @asymmetrik/fhir-qb
+yarn add @bluehalo/fhir-qb
 ```
 
 ## Arguments
 
-`@asymmetrik/fhir-qb` exports a single class called QueryBuilder. The QueryBuilder constructor takes 4 arguments:
+`@bluehalo/fhir-qb` exports a single class called QueryBuilder. The QueryBuilder constructor takes 4 arguments:
 
 #### `packageName`
 
-Query builder implementation package to be required. Default: `@asymmetrik/fhir-qb-mongo`
+Query builder implementation package to be required. Default: `@bluehalo/fhir-qb-mongo`
 
 #### `globalParameterDefinitions`
 

--- a/packages/fhir-qb/index.js
+++ b/packages/fhir-qb/index.js
@@ -1,7 +1,7 @@
 const moment = require('moment');
 const xRegExp = require('xregexp');
 const math = require('mathjs');
-const sanitize = require('@asymmetrik/fhir-sanitize-param');
+const sanitize = require('@bluehalo/fhir-sanitize-param');
 
 const prefixes = {
   EQUAL: 'eq',
@@ -45,7 +45,7 @@ const supportedColumnIdentifierStrategies = ['xpath', 'parameter'];
 
 class QueryBuilder {
   constructor({
-    packageName = '@asymmetrik/fhir-qb-mongo',
+    packageName = '@bluehalo/fhir-qb-mongo',
     globalParameterDefinitions = {},
     pageParam = 'page',
     resultsPerPage = 10,

--- a/packages/fhir-qb/package.json
+++ b/packages/fhir-qb/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/fhir-qb",
+  "name": "@bluehalo/fhir-qb",
   "version": "0.12.6",
   "description": "FHIR query builder",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/fhir-qb"
@@ -32,8 +32,8 @@
     "verbose": true
   },
   "dependencies": {
-    "@asymmetrik/fhir-qb-mongo": "^0.12.3",
-    "@asymmetrik/fhir-sanitize-param": "^1.1.6",
+    "@bluehalo/fhir-qb-mongo": "^0.12.3",
+    "@bluehalo/fhir-sanitize-param": "^1.1.6",
     "mathjs": "^9.5.1",
     "moment": "^2.24.0",
     "sequelize": "^6.8.0",

--- a/packages/fhir-response-util/CHANGELOG.md
+++ b/packages/fhir-response-util/CHANGELOG.md
@@ -7,4 +7,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- Package/fhir response utils ([#11](https://github.com/Asymmetrik/phx-tools/issues/11)) ([7d2073d](https://github.com/Asymmetrik/phx-tools/commit/7d2073d))
+- Package/fhir response utils ([#11](https://github.com/BlueHalo/phx-tools/issues/11)) ([7d2073d](https://github.com/BlueHalo/phx-tools/commit/7d2073d))

--- a/packages/fhir-response-util/README.md
+++ b/packages/fhir-response-util/README.md
@@ -5,14 +5,14 @@
 ## Install
 
 ```shell
-yarn add @asymmetrik/fhir-response-util
+yarn add @bluehalo/fhir-response-util
 ```
 
 ## Usage
 
 The response utility exposes the following methods which can be used to for different scenarios and different types of responses. They all make certain assumptions about the arguments they receive which are documented below in the [arguments](#arguments) section.
 
-This is designed to be used in [node-fhir-server-core](https://github.com/Asymmetrik/node-fhir-server-core) and similar FHIR servers. There is some pseudocode with each method's description to give an idea of how this might work. If you read the source code for resource controllers in node-fhir-server-core, you can see how we are using this internally.
+This is designed to be used in [node-fhir-server-core](https://github.com/BlueHalo/node-fhir-server-core) and similar FHIR servers. There is some pseudocode with each method's description to give an idea of how this might work. If you read the source code for resource controllers in node-fhir-server-core, you can see how we are using this internally.
 
 ### read
 
@@ -21,7 +21,7 @@ This is designed to be used in [node-fhir-server-core](https://github.com/Asymme
 This will set the correct Content-Type and status code while sending the json back to the client.
 
 ```javascript
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 // Some controller
 function getPatientsController(req, res, next) {
@@ -45,7 +45,7 @@ function getPatientsController(req, res, next) {
 This will set the correct Content-Type and status code while sending the json back to the client.
 
 ```javascript
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 // Some controller
 function getPatientController(req, res, next) {
@@ -68,7 +68,7 @@ function getPatientController(req, res, next) {
 This will set the correct Content-Location, Location, and ETag headers. As well as set the correct status code.
 
 ```javascript
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 // Some controller
 function createPatientController(req, res, next) {
@@ -94,7 +94,7 @@ function createPatientController(req, res, next) {
 This will set the correct Content-Location, Last-Modified, Location, and ETag headers. As well as set the correct Content-Type and status code.
 
 ```javascript
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 // Some controller
 function updatePatientController(req, res, next) {
@@ -120,7 +120,7 @@ function updatePatientController(req, res, next) {
 This will set the correct ETag header and status code.
 
 ```javascript
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 // Some controller
 function removePatientController(req, res, next) {
@@ -145,7 +145,7 @@ function removePatientController(req, res, next) {
 This will set the correct Content-Type and status code while sending the json back to the client.
 
 ```javascript
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 // Some controller
 function getPatientHistoryController(req, res, next) {

--- a/packages/fhir-response-util/package.json
+++ b/packages/fhir-response-util/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/fhir-response-util",
+  "name": "@bluehalo/fhir-response-util",
   "version": "1.2.4",
   "description": "Utility for handling the headers, content, and status types for a response.",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/fhir-response-util"

--- a/packages/fhir-sanitize-param/CHANGELOG.md
+++ b/packages/fhir-sanitize-param/CHANGELOG.md
@@ -3,27 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.1.2](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-sanitize-param@1.1.1...@asymmetrik/fhir-sanitize-param@1.1.2) (2019-05-03)
+## [1.1.2](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-sanitize-param@1.1.1...@bluehalo/fhir-sanitize-param@1.1.2) (2019-05-03)
 
-**Note:** Version bump only for package @asymmetrik/fhir-sanitize-param
+**Note:** Version bump only for package @bluehalo/fhir-sanitize-param
 
-## [1.1.1](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-sanitize-param@1.0.0...@asymmetrik/fhir-sanitize-param@1.1.1) (2019-04-05)
+## [1.1.1](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-sanitize-param@1.0.0...@bluehalo/fhir-sanitize-param@1.1.1) (2019-04-05)
 
-**Note:** Version bump only for package @asymmetrik/fhir-sanitize-param
+**Note:** Version bump only for package @bluehalo/fhir-sanitize-param
 
-# [1.1.0](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-sanitize-param@1.0.0...@asymmetrik/fhir-sanitize-param@1.1.0) (2019-03-20)
+# [1.1.0](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-sanitize-param@1.0.0...@bluehalo/fhir-sanitize-param@1.1.0) (2019-03-20)
 
 ### Features
 
-- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/Asymmetrik/phx-tools/commit/fefce17))
-- update fhir-sanitize-params and phx-tools tests ([3466c1b](https://github.com/Asymmetrik/phx-tools/commit/3466c1b))
+- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/BlueHalo/phx-tools/commit/fefce17))
+- update fhir-sanitize-params and phx-tools tests ([3466c1b](https://github.com/BlueHalo/phx-tools/commit/3466c1b))
 
-# [1.0.0](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/fhir-sanitize-param@0.9.1...@asymmetrik/fhir-sanitize-param@1.0.0) (2019-02-13)
+# [1.0.0](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/fhir-sanitize-param@0.9.1...@bluehalo/fhir-sanitize-param@1.0.0) (2019-02-13)
 
 ### Bug Fixes
 
-- Fixed paths on repository url and homepage ([#9](https://github.com/Asymmetrik/phx-tools/issues/9)) ([d662ec8](https://github.com/Asymmetrik/phx-tools/commit/d662ec8))
+- Fixed paths on repository url and homepage ([#9](https://github.com/BlueHalo/phx-tools/issues/9)) ([d662ec8](https://github.com/BlueHalo/phx-tools/commit/d662ec8))
 
 ### Features
 
-- add support for more fhir data types ([#10](https://github.com/Asymmetrik/phx-tools/issues/10)) ([ec214a0](https://github.com/Asymmetrik/phx-tools/commit/ec214a0))
+- add support for more fhir data types ([#10](https://github.com/BlueHalo/phx-tools/issues/10)) ([ec214a0](https://github.com/BlueHalo/phx-tools/commit/ec214a0))

--- a/packages/fhir-sanitize-param/README.md
+++ b/packages/fhir-sanitize-param/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```shell
-yarn add @asymmetrik/fhir-sanitize-param
+yarn add @bluehalo/fhir-sanitize-param
 ```
 
 ## Usage
@@ -14,4 +14,4 @@ This package exports a number of functions meant for sanitizing different data t
 The functions available from this package are:
 `sanitizeBoolean, sanitizeDate, sanitizeNumber, sanitizeQuantity, sanitizeString, sanitizeToken`
 
-See [fhir-sanitize-param tests](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages/fhir-sanitize-param/index.test.js) for more usage examples.
+See [fhir-sanitize-param tests](https://github.com/BlueHalo/node-fhir-server-core/tree/master/packages/fhir-sanitize-param/index.test.js) for more usage examples.

--- a/packages/fhir-sanitize-param/package.json
+++ b/packages/fhir-sanitize-param/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/fhir-sanitize-param",
+  "name": "@bluehalo/fhir-sanitize-param",
   "version": "1.1.7",
   "description": "Sanitization tool for FHIR parameters",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/fhir-sanitize-param"

--- a/packages/fhir-secrets/CHANGELOG.md
+++ b/packages/fhir-secrets/CHANGELOG.md
@@ -5,4 +5,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 0.9.1 (2019-04-05)
 
-**Note:** Version bump only for package @asymmetrik/fhir-secrets
+**Note:** Version bump only for package @bluehalo/fhir-secrets

--- a/packages/fhir-secrets/README.md
+++ b/packages/fhir-secrets/README.md
@@ -5,7 +5,7 @@
 # Install
 
 ```shell
-yarn add @asymmetrik/fhir-secrets
+yarn add @bluehalo/fhir-secrets
 ```
 
 ## Prerequisites
@@ -19,7 +19,7 @@ yarn add @asymmetrik/fhir-secrets
 Depending on where you are running this code, the setup portion may change. If you have a default AWS profile with region and everything else set, you can use the decrypt function as follows:
 
 ```javascript
-const secrets = require('@asymmetrik/fhir-secrets');
+const secrets = require('@bluehalo/fhir-secrets');
 
 // This is output when you encrypt a secret with kms
 // https://docs.aws.amazon.com/cli/latest/reference/kms/encrypt.html
@@ -38,7 +38,7 @@ secrets
 If you need to configure the setup process with region or other properties in the client class constructor, you can do so and chain the process.
 
 ```javascript
-const secrets = require('@asymmetrik/fhir-secrets');
+const secrets = require('@bluehalo/fhir-secrets');
 
 secrets
   .configure({ region: 'us-east-2' })
@@ -47,7 +47,7 @@ secrets
   .catch(console.error);
 ```
 
-See [fhir-secrets tests](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages/fhir-secrets/index.test.js) for more usage examples.
+See [fhir-secrets tests](https://github.com/BlueHalo/node-fhir-server-core/tree/master/packages/fhir-secrets/index.test.js) for more usage examples.
 
 ## Methods
 

--- a/packages/fhir-secrets/package.json
+++ b/packages/fhir-secrets/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/fhir-secrets",
+  "name": "@bluehalo/fhir-secrets",
   "version": "0.9.7",
   "description": "AWS KMS Secrets retrieval promisified",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/fhir-secrets"

--- a/packages/node-fhir-server-core/CHANGELOG.md
+++ b/packages/node-fhir-server-core/CHANGELOG.md
@@ -33,172 +33,172 @@
 - import support for custom baseUrls ([e242268](https://github.com/bluehalo/node-fhir-server-core/commit/e24226850b7e87f63a2346036109c9f9d410ef6b))
 - improve package bundling ([a30db64](https://github.com/bluehalo/node-fhir-server-core/commit/a30db64f8f3f9e2015b0138f8c931a3c2039df52))
 
-## [2.2.4](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.10...2.2.4) (2021-11-15)
+## [2.2.4](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.10...2.2.4) (2021-11-15)
 
 ### Bug Fixes
 
-- add allergyintolerance ([a91bc21](https://github.com/Asymmetrik/node-fhir-server-core/commit/a91bc210bff103d3bb8a68a8ca89a0b028ace04e))
-- add allergyintrolerance controller and default to r4 if no version is found ([85af3a2](https://github.com/Asymmetrik/node-fhir-server-core/commit/85af3a279bcd37132f9516400fb91acef90c8eba))
-- add mock ([bd0f42c](https://github.com/Asymmetrik/node-fhir-server-core/commit/bd0f42c8f52f83d4ff546d0b3b1c2c53596c1d49))
-- add value meta properties ([f4381a7](https://github.com/Asymmetrik/node-fhir-server-core/commit/f4381a7b65b86de6cfcfc1a14cf373bda5ce70df))
-- bump lerna ([5256ee5](https://github.com/Asymmetrik/node-fhir-server-core/commit/5256ee5b325a71e646838b59d4a293a1cb1090f2))
-- **docs:** update doc links ([2651a11](https://github.com/Asymmetrik/node-fhir-server-core/commit/2651a110b30bf9c6ce11fea4681d218b66a65e3c))
-- export bundleentry ([255e012](https://github.com/Asymmetrik/node-fhir-server-core/commit/255e01288626fc24e7fb8cb2ab29cd8bae57732e))
-- fix bug involving custom baseUrls ([b27ea72](https://github.com/Asymmetrik/node-fhir-server-core/commit/b27ea728992dba1b022953b1286fb5e51e646a83))
-- fix bug involving custom baseUrls ([d825ad3](https://github.com/Asymmetrik/node-fhir-server-core/commit/d825ad30ef94531b5ae2b75d8dcc382adaf6d1d3))
-- ignore long lines ([6272247](https://github.com/Asymmetrik/node-fhir-server-core/commit/6272247943afd336cd08f54273cd68b70666db12))
-- just return an R4 operation outcome on lost URLs ([86451ec](https://github.com/Asymmetrik/node-fhir-server-core/commit/86451ec2a362b22e39674c99cff48f241f0a57d0))
-- remove test for fixed issue ([813c9f3](https://github.com/Asymmetrik/node-fhir-server-core/commit/813c9f3042228605e89d564e3841e2f1449b3be9))
-- update baseUrl logic ([c12c21a](https://github.com/Asymmetrik/node-fhir-server-core/commit/c12c21a3e98ad952f38cba188d2eda9e87f279d9))
-- update description ([ac57130](https://github.com/Asymmetrik/node-fhir-server-core/commit/ac571301c18af48c17f5535102aa7e928eea7c94))
-- update package version ([5297521](https://github.com/Asymmetrik/node-fhir-server-core/commit/52975217a1eb9d89228838dfd10094b97241a65a))
-- update tests ([47bc4b0](https://github.com/Asymmetrik/node-fhir-server-core/commit/47bc4b0cc42f047558332012bdb42add612d17be))
-- update tests ([b9892cb](https://github.com/Asymmetrik/node-fhir-server-core/commit/b9892cb1e5705046367cfe6418426cd764d4385f))
-- updated reference to uri ([82e16a5](https://github.com/Asymmetrik/node-fhir-server-core/commit/82e16a55165fce04ca066827113695cce1bbaa17))
-- updated token options ([d86e35b](https://github.com/Asymmetrik/node-fhir-server-core/commit/d86e35b35ccd4193f4f98fb423ca8f3a19994198))
+- add allergyintolerance ([a91bc21](https://github.com/BlueHalo/node-fhir-server-core/commit/a91bc210bff103d3bb8a68a8ca89a0b028ace04e))
+- add allergyintrolerance controller and default to r4 if no version is found ([85af3a2](https://github.com/BlueHalo/node-fhir-server-core/commit/85af3a279bcd37132f9516400fb91acef90c8eba))
+- add mock ([bd0f42c](https://github.com/BlueHalo/node-fhir-server-core/commit/bd0f42c8f52f83d4ff546d0b3b1c2c53596c1d49))
+- add value meta properties ([f4381a7](https://github.com/BlueHalo/node-fhir-server-core/commit/f4381a7b65b86de6cfcfc1a14cf373bda5ce70df))
+- bump lerna ([5256ee5](https://github.com/BlueHalo/node-fhir-server-core/commit/5256ee5b325a71e646838b59d4a293a1cb1090f2))
+- **docs:** update doc links ([2651a11](https://github.com/BlueHalo/node-fhir-server-core/commit/2651a110b30bf9c6ce11fea4681d218b66a65e3c))
+- export bundleentry ([255e012](https://github.com/BlueHalo/node-fhir-server-core/commit/255e01288626fc24e7fb8cb2ab29cd8bae57732e))
+- fix bug involving custom baseUrls ([b27ea72](https://github.com/BlueHalo/node-fhir-server-core/commit/b27ea728992dba1b022953b1286fb5e51e646a83))
+- fix bug involving custom baseUrls ([d825ad3](https://github.com/BlueHalo/node-fhir-server-core/commit/d825ad30ef94531b5ae2b75d8dcc382adaf6d1d3))
+- ignore long lines ([6272247](https://github.com/BlueHalo/node-fhir-server-core/commit/6272247943afd336cd08f54273cd68b70666db12))
+- just return an R4 operation outcome on lost URLs ([86451ec](https://github.com/BlueHalo/node-fhir-server-core/commit/86451ec2a362b22e39674c99cff48f241f0a57d0))
+- remove test for fixed issue ([813c9f3](https://github.com/BlueHalo/node-fhir-server-core/commit/813c9f3042228605e89d564e3841e2f1449b3be9))
+- update baseUrl logic ([c12c21a](https://github.com/BlueHalo/node-fhir-server-core/commit/c12c21a3e98ad952f38cba188d2eda9e87f279d9))
+- update description ([ac57130](https://github.com/BlueHalo/node-fhir-server-core/commit/ac571301c18af48c17f5535102aa7e928eea7c94))
+- update package version ([5297521](https://github.com/BlueHalo/node-fhir-server-core/commit/52975217a1eb9d89228838dfd10094b97241a65a))
+- update tests ([47bc4b0](https://github.com/BlueHalo/node-fhir-server-core/commit/47bc4b0cc42f047558332012bdb42add612d17be))
+- update tests ([b9892cb](https://github.com/BlueHalo/node-fhir-server-core/commit/b9892cb1e5705046367cfe6418426cd764d4385f))
+- updated reference to uri ([82e16a5](https://github.com/BlueHalo/node-fhir-server-core/commit/82e16a55165fce04ca066827113695cce1bbaa17))
+- updated token options ([d86e35b](https://github.com/BlueHalo/node-fhir-server-core/commit/d86e35b35ccd4193f4f98fb423ca8f3a19994198))
 
 ### Features
 
-- add allergyintolerance schema ([268cb8a](https://github.com/Asymmetrik/node-fhir-server-core/commit/268cb8a8ca0a8659fbaa0c341d612f7cf8986d17))
-- add index files for each resource ([7410e4a](https://github.com/Asymmetrik/node-fhir-server-core/commit/7410e4a1090a7718d4b4170c37409c044ba2b72f))
-- add snyk ([b9d57bb](https://github.com/Asymmetrik/node-fhir-server-core/commit/b9d57bb61ba05bc26a6938d061d0e9fbf90343e7))
-- allow for the ability to specify a baseUrl for profiles ([933a77b](https://github.com/Asymmetrik/node-fhir-server-core/commit/933a77bd47b9feda106346d7d8767d964b7bf51a))
-- allow for the ability to specify a list of custom baseUrls ([156de6b](https://github.com/Asymmetrik/node-fhir-server-core/commit/156de6b0cda37e88e16d1bc8a44df84426eaab3d))
-- fix operations route ([fb79d06](https://github.com/Asymmetrik/node-fhir-server-core/commit/fb79d0675dc4b5010dab1cd4606d16df254506bf))
-- import support for custom baseUrls ([e242268](https://github.com/Asymmetrik/node-fhir-server-core/commit/e24226850b7e87f63a2346036109c9f9d410ef6b))
-- improve package bundling ([a30db64](https://github.com/Asymmetrik/node-fhir-server-core/commit/a30db64f8f3f9e2015b0138f8c931a3c2039df52))
+- add allergyintolerance schema ([268cb8a](https://github.com/BlueHalo/node-fhir-server-core/commit/268cb8a8ca0a8659fbaa0c341d612f7cf8986d17))
+- add index files for each resource ([7410e4a](https://github.com/BlueHalo/node-fhir-server-core/commit/7410e4a1090a7718d4b4170c37409c044ba2b72f))
+- add snyk ([b9d57bb](https://github.com/BlueHalo/node-fhir-server-core/commit/b9d57bb61ba05bc26a6938d061d0e9fbf90343e7))
+- allow for the ability to specify a baseUrl for profiles ([933a77b](https://github.com/BlueHalo/node-fhir-server-core/commit/933a77bd47b9feda106346d7d8767d964b7bf51a))
+- allow for the ability to specify a list of custom baseUrls ([156de6b](https://github.com/BlueHalo/node-fhir-server-core/commit/156de6b0cda37e88e16d1bc8a44df84426eaab3d))
+- fix operations route ([fb79d06](https://github.com/BlueHalo/node-fhir-server-core/commit/fb79d0675dc4b5010dab1cd4606d16df254506bf))
+- import support for custom baseUrls ([e242268](https://github.com/BlueHalo/node-fhir-server-core/commit/e24226850b7e87f63a2346036109c9f9d410ef6b))
+- improve package bundling ([a30db64](https://github.com/BlueHalo/node-fhir-server-core/commit/a30db64f8f3f9e2015b0138f8c931a3c2039df52))
 
-# [2.2.0](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.10...2.2.0) (2020-09-29)
+# [2.2.0](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.10...2.2.0) (2020-09-29)
 
 ### Bug Fixes
 
-- add allergyintolerance ([a91bc21](https://github.com/Asymmetrik/node-fhir-server-core/commit/a91bc210bff103d3bb8a68a8ca89a0b028ace04e))
-- add allergyintrolerance controller and default to r4 if no version is found ([85af3a2](https://github.com/Asymmetrik/node-fhir-server-core/commit/85af3a279bcd37132f9516400fb91acef90c8eba))
-- fix bug involving custom baseUrls ([d825ad3](https://github.com/Asymmetrik/node-fhir-server-core/commit/d825ad30ef94531b5ae2b75d8dcc382adaf6d1d3))
-- just return an R4 operation outcome on lost URLs ([86451ec](https://github.com/Asymmetrik/node-fhir-server-core/commit/86451ec2a362b22e39674c99cff48f241f0a57d0))
+- add allergyintolerance ([a91bc21](https://github.com/BlueHalo/node-fhir-server-core/commit/a91bc210bff103d3bb8a68a8ca89a0b028ace04e))
+- add allergyintrolerance controller and default to r4 if no version is found ([85af3a2](https://github.com/BlueHalo/node-fhir-server-core/commit/85af3a279bcd37132f9516400fb91acef90c8eba))
+- fix bug involving custom baseUrls ([d825ad3](https://github.com/BlueHalo/node-fhir-server-core/commit/d825ad30ef94531b5ae2b75d8dcc382adaf6d1d3))
+- just return an R4 operation outcome on lost URLs ([86451ec](https://github.com/BlueHalo/node-fhir-server-core/commit/86451ec2a362b22e39674c99cff48f241f0a57d0))
 
 ### Features
 
-- add allergyintolerance schema ([268cb8a](https://github.com/Asymmetrik/node-fhir-server-core/commit/268cb8a8ca0a8659fbaa0c341d612f7cf8986d17))
-- add index files for each resource ([7410e4a](https://github.com/Asymmetrik/node-fhir-server-core/commit/7410e4a1090a7718d4b4170c37409c044ba2b72f))
-- allow for the ability to specify a baseUrl for profiles ([933a77b](https://github.com/Asymmetrik/node-fhir-server-core/commit/933a77bd47b9feda106346d7d8767d964b7bf51a))
-- allow for the ability to specify a list of custom baseUrls ([156de6b](https://github.com/Asymmetrik/node-fhir-server-core/commit/156de6b0cda37e88e16d1bc8a44df84426eaab3d))
-- fix operations route ([fb79d06](https://github.com/Asymmetrik/node-fhir-server-core/commit/fb79d0675dc4b5010dab1cd4606d16df254506bf))
-- import support for custom baseUrls ([e242268](https://github.com/Asymmetrik/node-fhir-server-core/commit/e24226850b7e87f63a2346036109c9f9d410ef6b))
-- improve package bundling ([a30db64](https://github.com/Asymmetrik/node-fhir-server-core/commit/a30db64f8f3f9e2015b0138f8c931a3c2039df52))
+- add allergyintolerance schema ([268cb8a](https://github.com/BlueHalo/node-fhir-server-core/commit/268cb8a8ca0a8659fbaa0c341d612f7cf8986d17))
+- add index files for each resource ([7410e4a](https://github.com/BlueHalo/node-fhir-server-core/commit/7410e4a1090a7718d4b4170c37409c044ba2b72f))
+- allow for the ability to specify a baseUrl for profiles ([933a77b](https://github.com/BlueHalo/node-fhir-server-core/commit/933a77bd47b9feda106346d7d8767d964b7bf51a))
+- allow for the ability to specify a list of custom baseUrls ([156de6b](https://github.com/BlueHalo/node-fhir-server-core/commit/156de6b0cda37e88e16d1bc8a44df84426eaab3d))
+- fix operations route ([fb79d06](https://github.com/BlueHalo/node-fhir-server-core/commit/fb79d0675dc4b5010dab1cd4606d16df254506bf))
+- import support for custom baseUrls ([e242268](https://github.com/BlueHalo/node-fhir-server-core/commit/e24226850b7e87f63a2346036109c9f9d410ef6b))
+- improve package bundling ([a30db64](https://github.com/BlueHalo/node-fhir-server-core/commit/a30db64f8f3f9e2015b0138f8c931a3c2039df52))
 
-## [2.1.3](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.10...2.1.3) (2020-09-23)
+## [2.1.3](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.10...2.1.3) (2020-09-23)
 
 ### Bug Fixes
 
-- add allergyintolerance ([a91bc21](https://github.com/Asymmetrik/node-fhir-server-core/commit/a91bc210bff103d3bb8a68a8ca89a0b028ace04e))
-- add allergyintrolerance controller and default to r4 if no version is found ([85af3a2](https://github.com/Asymmetrik/node-fhir-server-core/commit/85af3a279bcd37132f9516400fb91acef90c8eba))
-- just return an R4 operation outcome on lost URLs ([86451ec](https://github.com/Asymmetrik/node-fhir-server-core/commit/86451ec2a362b22e39674c99cff48f241f0a57d0))
+- add allergyintolerance ([a91bc21](https://github.com/BlueHalo/node-fhir-server-core/commit/a91bc210bff103d3bb8a68a8ca89a0b028ace04e))
+- add allergyintrolerance controller and default to r4 if no version is found ([85af3a2](https://github.com/BlueHalo/node-fhir-server-core/commit/85af3a279bcd37132f9516400fb91acef90c8eba))
+- just return an R4 operation outcome on lost URLs ([86451ec](https://github.com/BlueHalo/node-fhir-server-core/commit/86451ec2a362b22e39674c99cff48f241f0a57d0))
 
 ### Features
 
-- add allergyintolerance schema ([268cb8a](https://github.com/Asymmetrik/node-fhir-server-core/commit/268cb8a8ca0a8659fbaa0c341d612f7cf8986d17))
-- add index files for each resource ([7410e4a](https://github.com/Asymmetrik/node-fhir-server-core/commit/7410e4a1090a7718d4b4170c37409c044ba2b72f))
-- improve package bundling ([a30db64](https://github.com/Asymmetrik/node-fhir-server-core/commit/a30db64f8f3f9e2015b0138f8c931a3c2039df52))
+- add allergyintolerance schema ([268cb8a](https://github.com/BlueHalo/node-fhir-server-core/commit/268cb8a8ca0a8659fbaa0c341d612f7cf8986d17))
+- add index files for each resource ([7410e4a](https://github.com/BlueHalo/node-fhir-server-core/commit/7410e4a1090a7718d4b4170c37409c044ba2b72f))
+- improve package bundling ([a30db64](https://github.com/BlueHalo/node-fhir-server-core/commit/a30db64f8f3f9e2015b0138f8c931a3c2039df52))
 
-## [2.1.2](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.10...2.1.2) (2020-09-23)
+## [2.1.2](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.10...2.1.2) (2020-09-23)
 
 ### Bug Fixes
 
-- add allergyintolerance ([a91bc21](https://github.com/Asymmetrik/node-fhir-server-core/commit/a91bc210bff103d3bb8a68a8ca89a0b028ace04e))
-- just return an R4 operation outcome on lost URLs ([86451ec](https://github.com/Asymmetrik/node-fhir-server-core/commit/86451ec2a362b22e39674c99cff48f241f0a57d0))
+- add allergyintolerance ([a91bc21](https://github.com/BlueHalo/node-fhir-server-core/commit/a91bc210bff103d3bb8a68a8ca89a0b028ace04e))
+- just return an R4 operation outcome on lost URLs ([86451ec](https://github.com/BlueHalo/node-fhir-server-core/commit/86451ec2a362b22e39674c99cff48f241f0a57d0))
 
 ### Features
 
-- add index files for each resource ([7410e4a](https://github.com/Asymmetrik/node-fhir-server-core/commit/7410e4a1090a7718d4b4170c37409c044ba2b72f))
-- improve package bundling ([a30db64](https://github.com/Asymmetrik/node-fhir-server-core/commit/a30db64f8f3f9e2015b0138f8c931a3c2039df52))
+- add index files for each resource ([7410e4a](https://github.com/BlueHalo/node-fhir-server-core/commit/7410e4a1090a7718d4b4170c37409c044ba2b72f))
+- improve package bundling ([a30db64](https://github.com/BlueHalo/node-fhir-server-core/commit/a30db64f8f3f9e2015b0138f8c931a3c2039df52))
 
-## [2.0.11](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.10...2.0.11) (2020-09-02)
+## [2.0.11](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.10...2.0.11) (2020-09-02)
 
 - Upgrade fhir-response-utils to respond with a 404 on Search By ID
 
-## [2.0.10](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.9...2.0.10) (2020-07-01)
+## [2.0.10](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.9...2.0.10) (2020-07-01)
 
 ### Bug Fixes
 
-- Fix dosageAndRate schema ([4f51d3e](https://github.com/Asymmetrik/node-fhir-server-core/commit/4f51d3e3cd073159850fce15a22d7969693e5d3b)
+- Fix dosageAndRate schema ([4f51d3e](https://github.com/BlueHalo/node-fhir-server-core/commit/4f51d3e3cd073159850fce15a22d7969693e5d3b)
 
-## [2.0.9](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.7...2.0.9) (2020-06-24)
+## [2.0.9](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.7...2.0.9) (2020-06-24)
 
 ### Bug Fixes
 
-- .snyk & package.json to reduce vulnerabilities ([0980bc7](https://github.com/Asymmetrik/node-fhir-server-core/commit/0980bc78178fee4d015bfbdb8a79f94a7e2d9433))
-- .snyk & package.json to reduce vulnerabilities ([a807586](https://github.com/Asymmetrik/node-fhir-server-core/commit/a80758644059e7b87da1381a51d5d1ba95b0885c))
-- linting problems ([1d3b27f](https://github.com/Asymmetrik/node-fhir-server-core/commit/1d3b27f5ad3db830eee102790a6ad7a6f8a1c3bf))
-- linting problems ([1dc4d7f](https://github.com/Asymmetrik/node-fhir-server-core/commit/1dc4d7fe3467098d301953376c1f61a4d4fec42d))
-- package.json, yarn.lock & .snyk to reduce vulnerabilities ([1177927](https://github.com/Asymmetrik/node-fhir-server-core/commit/1177927b4c9b5d6aaa761e5434e58d9314835615))
-- package.json, yarn.lock & .snyk to reduce vulnerabilities ([55a775f](https://github.com/Asymmetrik/node-fhir-server-core/commit/55a775f5cf15691fd4d407172e2293bac70f66dd))
-- potentially fix travis ci (let's see) ([114df8e](https://github.com/Asymmetrik/node-fhir-server-core/commit/114df8e6224f2823d2ecd47969d899ce7c86cc8f))
-- update node engine ([fcf5387](https://github.com/Asymmetrik/node-fhir-server-core/commit/fcf53873ee6a3cd99c84f80b2518a83ec4e508fd))
-- use before_install ([bb2e02b](https://github.com/Asymmetrik/node-fhir-server-core/commit/bb2e02baefb77b505f1fc9582dfe817e166ffc52))
-- use latest node ([eeb5717](https://github.com/Asymmetrik/node-fhir-server-core/commit/eeb5717de36dc857849f8e3cd2398eae39425dca))
+- .snyk & package.json to reduce vulnerabilities ([0980bc7](https://github.com/BlueHalo/node-fhir-server-core/commit/0980bc78178fee4d015bfbdb8a79f94a7e2d9433))
+- .snyk & package.json to reduce vulnerabilities ([a807586](https://github.com/BlueHalo/node-fhir-server-core/commit/a80758644059e7b87da1381a51d5d1ba95b0885c))
+- linting problems ([1d3b27f](https://github.com/BlueHalo/node-fhir-server-core/commit/1d3b27f5ad3db830eee102790a6ad7a6f8a1c3bf))
+- linting problems ([1dc4d7f](https://github.com/BlueHalo/node-fhir-server-core/commit/1dc4d7fe3467098d301953376c1f61a4d4fec42d))
+- package.json, yarn.lock & .snyk to reduce vulnerabilities ([1177927](https://github.com/BlueHalo/node-fhir-server-core/commit/1177927b4c9b5d6aaa761e5434e58d9314835615))
+- package.json, yarn.lock & .snyk to reduce vulnerabilities ([55a775f](https://github.com/BlueHalo/node-fhir-server-core/commit/55a775f5cf15691fd4d407172e2293bac70f66dd))
+- potentially fix travis ci (let's see) ([114df8e](https://github.com/BlueHalo/node-fhir-server-core/commit/114df8e6224f2823d2ecd47969d899ce7c86cc8f))
+- update node engine ([fcf5387](https://github.com/BlueHalo/node-fhir-server-core/commit/fcf53873ee6a3cd99c84f80b2518a83ec4e508fd))
+- use before_install ([bb2e02b](https://github.com/BlueHalo/node-fhir-server-core/commit/bb2e02baefb77b505f1fc9582dfe817e166ffc52))
+- use latest node ([eeb5717](https://github.com/BlueHalo/node-fhir-server-core/commit/eeb5717de36dc857849f8e3cd2398eae39425dca))
 
 ### Features
 
-- **bundle:** Fix test that fails. ([6fb2de5](https://github.com/Asymmetrik/node-fhir-server-core/commit/6fb2de562f5f299f10fbecdc8475ca7c109cb0f1))
-- Add router for bundle using batch ([49087f8](https://github.com/Asymmetrik/node-fhir-server-core/commit/49087f82af34489c28d233401114a0e7589136b6))
-- **core:** add bundle batch ([7a28a54](https://github.com/Asymmetrik/node-fhir-server-core/commit/7a28a5410f84459fcbabe58906196ab1ded76efe))
+- **bundle:** Fix test that fails. ([6fb2de5](https://github.com/BlueHalo/node-fhir-server-core/commit/6fb2de562f5f299f10fbecdc8475ca7c109cb0f1))
+- Add router for bundle using batch ([49087f8](https://github.com/BlueHalo/node-fhir-server-core/commit/49087f82af34489c28d233401114a0e7589136b6))
+- **core:** add bundle batch ([7a28a54](https://github.com/BlueHalo/node-fhir-server-core/commit/7a28a5410f84459fcbabe58906196ab1ded76efe))
 
-## [2.0.7](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.6...2.0.7) (2019-12-05)
+## [2.0.7](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.6...2.0.7) (2019-12-05)
 
 - Upgrade jwk-to-pem
 
-## [2.0.6](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.5...2.0.6) (2019-11-15)
+## [2.0.6](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.5...2.0.6) (2019-11-15)
 
 - Miscellaneous Bug Fixes
 
-## [2.0.4](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.3...2.0.4) (2019-08-19)
+## [2.0.4](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.3...2.0.4) (2019-08-19)
 
 ### Bug Fixes
 
-- chore: updated and cleaned up documentation for readability + fix path.posix bug([#187](https://github.com/Asymmetrik/node-fhir-server-core/pull/187))([a32e628](https://github.com/Asymmetrik/node-fhir-server-core/pull/187/commits/a32e628))
+- chore: updated and cleaned up documentation for readability + fix path.posix bug([#187](https://github.com/BlueHalo/node-fhir-server-core/pull/187))([a32e628](https://github.com/BlueHalo/node-fhir-server-core/pull/187/commits/a32e628))
 
-## [2.0.3](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.2...2.0.3) (2019-06-17)
+## [2.0.3](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.2...2.0.3) (2019-06-17)
 
 ### Bug Fixes
 
-- authenticationMiddleware config ([#183](https://github.com/Asymmetrik/node-fhir-server-core/issues/183)) ([d9654bd](https://github.com/Asymmetrik/node-fhir-server-core/commit/d9654bd))
-- documentation error, error class missing message argument ([#177](https://github.com/Asymmetrik/node-fhir-server-core/issues/177)) ([3680a31](https://github.com/Asymmetrik/node-fhir-server-core/commit/3680a31))
+- authenticationMiddleware config ([#183](https://github.com/BlueHalo/node-fhir-server-core/issues/183)) ([d9654bd](https://github.com/BlueHalo/node-fhir-server-core/commit/d9654bd))
+- documentation error, error class missing message argument ([#177](https://github.com/BlueHalo/node-fhir-server-core/issues/177)) ([3680a31](https://github.com/BlueHalo/node-fhir-server-core/commit/3680a31))
 
 ### Features
 
-- pull in binary resource controller and parameters file into v4_0_0 ([#181](https://github.com/Asymmetrik/node-fhir-server-core/issues/181)) ([db5a344](https://github.com/Asymmetrik/node-fhir-server-core/commit/db5a344))
+- pull in binary resource controller and parameters file into v4_0_0 ([#181](https://github.com/BlueHalo/node-fhir-server-core/issues/181)) ([db5a344](https://github.com/BlueHalo/node-fhir-server-core/commit/db5a344))
 
-## [2.0.2](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.1...2.0.2) (2019-05-22)
-
-### Features
-
-- Custom errors and updated documentation ([#176](https://github.com/Asymmetrik/node-fhir-server-core/issues/176)) ([7e4a8bb](https://github.com/Asymmetrik/node-fhir-server-core/commit/7e4a8bb))
-
-## [2.0.1](https://github.com/Asymmetrik/node-fhir-server-core/compare/2.0.0...2.0.1) (2019-05-15)
-
-# [2.0.0](https://github.com/Asymmetrik/node-fhir-server-core/compare/1.4.2...2.0.0) (2019-05-15)
-
-## [1.4.2](https://github.com/Asymmetrik/node-fhir-server-core/compare/1.4.1...1.4.2) (2019-05-14)
-
-## [1.4.1](https://github.com/Asymmetrik/node-fhir-server-core/compare/1.4.0...1.4.1) (2019-04-09)
-
-### Bug Fixes
-
-- rename \_\_resourceType to resourceType in controllers ([#162](https://github.com/Asymmetrik/node-fhir-server-core/issues/162)) ([4934c89](https://github.com/Asymmetrik/node-fhir-server-core/commit/4934c89))
-
-# [1.4.0](https://github.com/Asymmetrik/node-fhir-server-core/compare/1.3.1...1.4.0) (2019-04-03)
-
-- feat/R4-resources (#157) ([d95a255](https://github.com/Asymmetrik/node-fhir-server-core/commit/d95a255)), closes [#157](https://github.com/Asymmetrik/node-fhir-server-core/issues/157)
-
-### Bug Fixes
-
-- update observation controller to use response utils ([#155](https://github.com/Asymmetrik/node-fhir-server-core/issues/155)) ([b529ce4](https://github.com/Asymmetrik/node-fhir-server-core/commit/b529ce4))
+## [2.0.2](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.1...2.0.2) (2019-05-22)
 
 ### Features
 
-- Custom Error Implementation ([#154](https://github.com/Asymmetrik/node-fhir-server-core/issues/154)) ([968377d](https://github.com/Asymmetrik/node-fhir-server-core/commit/968377d))
-- direct users to stack overflow for questions with new tags ([#158](https://github.com/Asymmetrik/node-fhir-server-core/issues/158)) ([3a83a43](https://github.com/Asymmetrik/node-fhir-server-core/commit/3a83a43))
+- Custom errors and updated documentation ([#176](https://github.com/BlueHalo/node-fhir-server-core/issues/176)) ([7e4a8bb](https://github.com/BlueHalo/node-fhir-server-core/commit/7e4a8bb))
+
+## [2.0.1](https://github.com/BlueHalo/node-fhir-server-core/compare/2.0.0...2.0.1) (2019-05-15)
+
+# [2.0.0](https://github.com/BlueHalo/node-fhir-server-core/compare/1.4.2...2.0.0) (2019-05-15)
+
+## [1.4.2](https://github.com/BlueHalo/node-fhir-server-core/compare/1.4.1...1.4.2) (2019-05-14)
+
+## [1.4.1](https://github.com/BlueHalo/node-fhir-server-core/compare/1.4.0...1.4.1) (2019-04-09)
+
+### Bug Fixes
+
+- rename \_\_resourceType to resourceType in controllers ([#162](https://github.com/BlueHalo/node-fhir-server-core/issues/162)) ([4934c89](https://github.com/BlueHalo/node-fhir-server-core/commit/4934c89))
+
+# [1.4.0](https://github.com/BlueHalo/node-fhir-server-core/compare/1.3.1...1.4.0) (2019-04-03)
+
+- feat/R4-resources (#157) ([d95a255](https://github.com/BlueHalo/node-fhir-server-core/commit/d95a255)), closes [#157](https://github.com/BlueHalo/node-fhir-server-core/issues/157)
+
+### Bug Fixes
+
+- update observation controller to use response utils ([#155](https://github.com/BlueHalo/node-fhir-server-core/issues/155)) ([b529ce4](https://github.com/BlueHalo/node-fhir-server-core/commit/b529ce4))
+
+### Features
+
+- Custom Error Implementation ([#154](https://github.com/BlueHalo/node-fhir-server-core/issues/154)) ([968377d](https://github.com/BlueHalo/node-fhir-server-core/commit/968377d))
+- direct users to stack overflow for questions with new tags ([#158](https://github.com/BlueHalo/node-fhir-server-core/issues/158)) ([3a83a43](https://github.com/BlueHalo/node-fhir-server-core/commit/3a83a43))
 
 ### BREAKING CHANGES
 
@@ -215,19 +215,19 @@
 - Incremented package.json version
 - fix: typo in capability statement
 
-## [1.3.1](https://github.com/Asymmetrik/node-fhir-server-core/compare/1.3.0...1.3.1) (2019-02-12)
+## [1.3.1](https://github.com/BlueHalo/node-fhir-server-core/compare/1.3.0...1.3.1) (2019-02-12)
 
 ### Bug Fixes
 
-- do not override the methods if defined in the config ([#124](https://github.com/Asymmetrik/node-fhir-server-core/issues/124)) ([6eff570](https://github.com/Asymmetrik/node-fhir-server-core/commit/6eff570))
-- issue with incorrect url being set when configuring CORS pre-flight ([#123](https://github.com/Asymmetrik/node-fhir-server-core/issues/123)) ([5b650a6](https://github.com/Asymmetrik/node-fhir-server-core/commit/5b650a6))
-- package.json to reduce vulnerabilities ([#144](https://github.com/Asymmetrik/node-fhir-server-core/issues/144)) ([95c82d4](https://github.com/Asymmetrik/node-fhir-server-core/commit/95c82d4))
+- do not override the methods if defined in the config ([#124](https://github.com/BlueHalo/node-fhir-server-core/issues/124)) ([6eff570](https://github.com/BlueHalo/node-fhir-server-core/commit/6eff570))
+- issue with incorrect url being set when configuring CORS pre-flight ([#123](https://github.com/BlueHalo/node-fhir-server-core/issues/123)) ([5b650a6](https://github.com/BlueHalo/node-fhir-server-core/commit/5b650a6))
+- package.json to reduce vulnerabilities ([#144](https://github.com/BlueHalo/node-fhir-server-core/issues/144)) ([95c82d4](https://github.com/BlueHalo/node-fhir-server-core/commit/95c82d4))
 
 ### Features
 
-- add deprecation utility for marking features in future releases ([#129](https://github.com/Asymmetrik/node-fhir-server-core/issues/129)) ([6ec5e25](https://github.com/Asymmetrik/node-fhir-server-core/commit/6ec5e25))
-- crud patch ([#132](https://github.com/Asymmetrik/node-fhir-server-core/issues/132)) ([ec613d4](https://github.com/Asymmetrik/node-fhir-server-core/commit/ec613d4))
-- custom metadata ([#128](https://github.com/Asymmetrik/node-fhir-server-core/issues/128)) ([27f6544](https://github.com/Asymmetrik/node-fhir-server-core/commit/27f6544))
-- Integrate Smart tools from phx-tools ([#131](https://github.com/Asymmetrik/node-fhir-server-core/issues/131)) ([c91acaa](https://github.com/Asymmetrik/node-fhir-server-core/commit/c91acaa))
+- add deprecation utility for marking features in future releases ([#129](https://github.com/BlueHalo/node-fhir-server-core/issues/129)) ([6ec5e25](https://github.com/BlueHalo/node-fhir-server-core/commit/6ec5e25))
+- crud patch ([#132](https://github.com/BlueHalo/node-fhir-server-core/issues/132)) ([ec613d4](https://github.com/BlueHalo/node-fhir-server-core/commit/ec613d4))
+- custom metadata ([#128](https://github.com/BlueHalo/node-fhir-server-core/issues/128)) ([27f6544](https://github.com/BlueHalo/node-fhir-server-core/commit/27f6544))
+- Integrate Smart tools from phx-tools ([#131](https://github.com/BlueHalo/node-fhir-server-core/issues/131)) ([c91acaa](https://github.com/BlueHalo/node-fhir-server-core/commit/c91acaa))
 
-# [1.2.0](https://github.com/Asymmetrik/node-fhir-server-core/compare/1.1.0...1.2.0) (2018-10-25)
+# [1.2.0](https://github.com/BlueHalo/node-fhir-server-core/compare/1.1.0...1.2.0) (2018-10-25)

--- a/packages/node-fhir-server-core/README.md
+++ b/packages/node-fhir-server-core/README.md
@@ -1,20 +1,20 @@
-# Asymmetrik FHIR API Server
+# BlueHalo FHIR API Server
 
-> A Secure Rest implementation for the [HL7 FHIR Specification](https://www.hl7.org/fhir/). For API documentation, please see [our documents](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/docs).
+> A Secure Rest implementation for the [HL7 FHIR Specification](https://www.hl7.org/fhir/). For API documentation, please see [our documents](https://github.com/BlueHalo/node-fhir-server-core/tree/master/docs).
 
-[![Build Status](https://travis-ci.org/Asymmetrik/node-fhir-server-core.svg?branch=develop)](https://travis-ci.org/Asymmetrik/node-fhir-server-core) [![Known Vulnerabilities](https://snyk.io/test/github/asymmetrik/node-fhir-server-core/badge.svg?targetFile=package.json)](https://snyk.io/test/github/asymmetrik/node-fhir-server-core?targetFile=package.json)
+[![Build Status](https://travis-ci.org/BlueHalo/node-fhir-server-core.svg?branch=develop)](https://travis-ci.org/BlueHalo/node-fhir-server-core) [![Known Vulnerabilities](https://snyk.io/test/github/asymmetrik/node-fhir-server-core/badge.svg?targetFile=package.json)](https://snyk.io/test/github/asymmetrik/node-fhir-server-core?targetFile=package.json)
 
-The Asymmetrik Extensible Server Framework for Healthcare allows organizations to build secure, interoperable solutions that can aggregate and expose healthcare resources via a common HL7® FHIR®-compatible REST API. This server framework currently supports **DSTU2** (1.0.2), **STU3** (3.0.1), and **R4** (4.0.0) simultaneously. You can decide to support all three or just one by editing the configuration.
+The BlueHalo Extensible Server Framework for Healthcare allows organizations to build secure, interoperable solutions that can aggregate and expose healthcare resources via a common HL7® FHIR®-compatible REST API. This server framework currently supports **DSTU2** (1.0.2), **STU3** (3.0.1), and **R4** (4.0.0) simultaneously. You can decide to support all three or just one by editing the configuration.
 
 The framework defines a core server, `node-fhir-server-core`, a simple, secure Node.js module built according to the FHIR specification and compliant with the [US Core](http://www.hl7.org/fhir/us/core/) implementation.
 
-For an example implementation using MongoDB, please refer to our Github repository that we used for the ONC FHIR Secure API Server Showdown Challenge: [https://github.com/Asymmetrik/node-fhir-server-mongo](https://github.com/Asymmetrik/node-fhir-server-mongo).
+For an example implementation using MongoDB, please refer to our Github repository that we used for the ONC FHIR Secure API Server Showdown Challenge: [https://github.com/BlueHalo/node-fhir-server-mongo](https://github.com/BlueHalo/node-fhir-server-mongo).
 
 <img src="https://www.asymmetrik.com/wp-content/uploads/2018/01/FHIR-Server-Architecture_Update.png" width="800">
 
 ## node-fhir-server-core@2.0.0
 
-Please view the [Migration Guide](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/docs/MIGRATION_2.0.0.md) for version `2.0.0`. We **will absolutely** continue supporting previous versions but **will prioritize** new features going to `2.0.0` unless we receive requests to retrofit them to older versions.
+Please view the [Migration Guide](https://github.com/BlueHalo/node-fhir-server-core/blob/master/docs/MIGRATION_2.0.0.md) for version `2.0.0`. We **will absolutely** continue supporting previous versions but **will prioritize** new features going to `2.0.0` unless we receive requests to retrofit them to older versions.
 
 ## Prerequisites
 
@@ -37,15 +37,15 @@ Please see our [Getting Started](./docs/GettingStarted.md) guide for a walkthrou
 
 Our project vision is to build an easy to use FHIR server that supports all resource profiles defined in the [US Core implementation guide](http://www.hl7.org/fhir/us/core/) and is built with security in mind from the ground up. We decided to use a plugin style architecture so implementors could focus on writing queries and not worry about all the other technical difficulties of securing the server. As this project matures, we plan to support more resources, custom extensions, versions, write capabilities, etc.
 
-We believe in establishing a robust security, especially when it comes to health information. Part of the ONC Secure API Server Challenge was to stand up a server and let penetration testers have a go at it (you can see their results [here](https://github.com/Asymmetrik/node-fhir-server-core/issues?utf8=%E2%9C%93&q=label%3A%22ONC+FHIR+Challenge+Vulnerability%22+)). We are committed to continuing this practice and we will continue fixing any vulnerabilities discovered so we can do our best to make this server as secure as possible. For authentication, we are actively working on methods for simplifying integration with [SMART on FHIR](http://docs.smarthealthit.org/).
+We believe in establishing a robust security, especially when it comes to health information. Part of the ONC Secure API Server Challenge was to stand up a server and let penetration testers have a go at it (you can see their results [here](https://github.com/BlueHalo/node-fhir-server-core/issues?utf8=%E2%9C%93&q=label%3A%22ONC+FHIR+Challenge+Vulnerability%22+)). We are committed to continuing this practice and we will continue fixing any vulnerabilities discovered so we can do our best to make this server as secure as possible. For authentication, we are actively working on methods for simplifying integration with [SMART on FHIR](http://docs.smarthealthit.org/).
 
 ## Contributing
 
-Please see [CONTRIBUTING.md](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/CONTRIBUTING.md) for more details regarding contributing issues or code.
+Please see [CONTRIBUTING.md](https://github.com/BlueHalo/node-fhir-server-core/blob/master/CONTRIBUTING.md) for more details regarding contributing issues or code.
 
 ## Questions
 
-If you are experiencing a bug, please feel free to file an [issue](https://github.com/Asymmetrik/node-fhir-server-core/issues). For general questions, please post them to [StackOverflow](https://stackoverflow.com/) with the tag `node-fhir-server-core` or `javascript-fhir`.
+If you are experiencing a bug, please feel free to file an [issue](https://github.com/BlueHalo/node-fhir-server-core/issues). For general questions, please post them to [StackOverflow](https://stackoverflow.com/) with the tag `node-fhir-server-core` or `javascript-fhir`.
 
 ## Attention
 
@@ -53,4 +53,4 @@ This library makes use of node's path module. This is potentially exploitable in
 
 ## License
 
-`@asymmetrik/node-fhir-server-core` is [MIT licensed](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/LICENSE).
+`@bluehalo/node-fhir-server-core` is [MIT licensed](https://github.com/BlueHalo/node-fhir-server-core/blob/master/LICENSE).

--- a/packages/node-fhir-server-core/package.json
+++ b/packages/node-fhir-server-core/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@asymmetrik/node-fhir-server-core",
+  "name": "@bluehalo/node-fhir-server-core",
   "version": "2.2.5",
   "description": "Node FHIR Rest API Server",
   "license": "MIT",
-  "author": "Asymmetrik Ltd.",
+  "author": "BlueHalo",
   "contributors": [
     "Robert Winterbottom <rwinterbottom@asymmetrik.com>",
     "Jon Lee <jlee@asymmetrik.com>",
@@ -43,8 +43,8 @@
     "verbose": true
   },
   "dependencies": {
-    "@asymmetrik/fhir-response-util": "^1.2.4",
-    "@asymmetrik/sof-scope-checker": "^1.0.7",
+    "@bluehalo/fhir-response-util": "^1.2.4",
+    "@bluehalo/sof-scope-checker": "^1.0.7",
     "@hapi/bourne": "^2.0.0",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",

--- a/packages/node-fhir-server-core/src/server/middleware/sof-scope.middleware.js
+++ b/packages/node-fhir-server-core/src/server/middleware/sof-scope.middleware.js
@@ -1,4 +1,4 @@
-const scopeChecker = require('@asymmetrik/sof-scope-checker');
+const scopeChecker = require('@bluehalo/sof-scope-checker');
 const noOpMiddleware = require('./noop.middleware.js');
 const { INTERACTIONS } = require('../../constants');
 const errors = require('../utils/error.utils');

--- a/packages/node-fhir-server-core/src/server/operations/operations.controller.js
+++ b/packages/node-fhir-server-core/src/server/operations/operations.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @description Controller for all POST operations

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/account.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/account.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/allergyintolerance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/allergyintolerance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/appointment.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/appointment.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/appointmentresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/appointmentresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/auditevent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/auditevent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/basic.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/basic.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/binary.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/binary.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/bodysite.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/bodysite.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/bundle.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/bundle.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/careplan.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/careplan.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/claim.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/claim.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/claimresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/claimresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/clinicalimpression.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/clinicalimpression.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/communication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/communication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/communicationrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/communicationrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/composition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/composition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/conceptmap.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/conceptmap.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/condition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/condition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/conformance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/conformance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/contract.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/contract.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/coverage.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/coverage.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/dataelement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/dataelement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/detectedissue.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/detectedissue.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/device.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/device.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/devicecomponent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/devicecomponent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/devicemetric.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/devicemetric.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/deviceuserequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/deviceuserequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/deviceusestatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/deviceusestatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/diagnosticorder.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/diagnosticorder.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/diagnosticreport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/diagnosticreport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/documentmanifest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/documentmanifest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/documentreference.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/documentreference.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/eligibilityrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/eligibilityrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/eligibilityresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/eligibilityresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/encounter.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/encounter.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/enrollmentrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/enrollmentrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/enrollmentresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/enrollmentresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/episodeofcare.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/episodeofcare.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/explanationofbenefit.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/explanationofbenefit.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/familymemberhistory.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/familymemberhistory.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/flag.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/flag.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/goal.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/goal.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/group.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/group.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/healthcareservice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/healthcareservice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/imagingobjectselection.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/imagingobjectselection.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/imagingstudy.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/imagingstudy.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/immunization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/immunization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/immunizationrecommendation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/immunizationrecommendation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/implementationguide.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/implementationguide.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/list.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/list.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/location.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/location.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/media.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/media.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medicationadministration.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medicationadministration.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medicationdispense.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medicationdispense.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medicationorder.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medicationorder.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medicationstatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/medicationstatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/messageheader.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/messageheader.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/namingsystem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/namingsystem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/nutritionorder.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/nutritionorder.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/observation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/observation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/operationdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/operationdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/order.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/order.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/orderresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/orderresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/organization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/organization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/patient.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/patient.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/paymentnotice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/paymentnotice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/paymentreconciliation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/paymentreconciliation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/person.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/person.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/practitioner.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/practitioner.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/procedure.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/procedure.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/procedurerequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/procedurerequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/processrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/processrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/processresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/processresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/provenance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/provenance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/questionnaire.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/questionnaire.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/questionnaireresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/questionnaireresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/referralrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/referralrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/relatedperson.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/relatedperson.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/resource.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/resource.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/riskassessment.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/riskassessment.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/schedule.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/schedule.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/searchparameter.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/searchparameter.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/slot.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/slot.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/specimen.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/specimen.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/structuredefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/structuredefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/subscription.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/subscription.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/substance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/substance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/supplydelivery.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/supplydelivery.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/supplyrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/supplyrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/testscript.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/testscript.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/valueset.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/valueset.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/visionprescription.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/1_0_2/controllers/visionprescription.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/account.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/account.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/activitydefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/activitydefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/adverseevent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/adverseevent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/allergyintolerance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/allergyintolerance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/appointment.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/appointment.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/appointmentresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/appointmentresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/auditevent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/auditevent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/basic.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/basic.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/binary.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/binary.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/bodysite.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/bodysite.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/bundle.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/bundle.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/capabilitystatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/capabilitystatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/careplan.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/careplan.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/careteam.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/careteam.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/chargeitem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/chargeitem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/claim.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/claim.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/claimresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/claimresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/clinicalimpression.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/clinicalimpression.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/codesystem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/codesystem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/communication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/communication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/communicationrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/communicationrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/compartmentdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/compartmentdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/composition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/composition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/conceptmap.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/conceptmap.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/condition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/condition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/consent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/consent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/contract.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/contract.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/coverage.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/coverage.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/dataelement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/dataelement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/detectedissue.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/detectedissue.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/device.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/device.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/devicecomponent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/devicecomponent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/devicemetric.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/devicemetric.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/devicerequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/devicerequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/deviceusestatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/deviceusestatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/diagnosticreport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/diagnosticreport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/documentmanifest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/documentmanifest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/documentreference.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/documentreference.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/domainresource.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/domainresource.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/eligibilityrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/eligibilityrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/eligibilityresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/eligibilityresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/encounter.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/encounter.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/endpoint.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/endpoint.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/enrollmentrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/enrollmentrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/enrollmentresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/enrollmentresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/episodeofcare.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/episodeofcare.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/expansionprofile.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/expansionprofile.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/explanationofbenefit.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/explanationofbenefit.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/familymemberhistory.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/familymemberhistory.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/flag.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/flag.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/goal.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/goal.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/graphdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/graphdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/group.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/group.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/guidanceresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/guidanceresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/healthcareservice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/healthcareservice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/imagingmanifest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/imagingmanifest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/imagingstudy.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/imagingstudy.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/immunization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/immunization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/immunizationrecommendation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/immunizationrecommendation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/implementationguide.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/implementationguide.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/library.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/library.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/linkage.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/linkage.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/list.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/list.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/location.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/location.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/measure.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/measure.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/measurereport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/measurereport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/media.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/media.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medicationadministration.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medicationadministration.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medicationdispense.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medicationdispense.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medicationrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medicationrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medicationstatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/medicationstatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/messagedefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/messagedefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/messageheader.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/messageheader.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/namingsystem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/namingsystem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/nutritionorder.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/nutritionorder.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/observation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/observation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/operationdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/operationdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/organization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/organization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/patient.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/patient.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/paymentnotice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/paymentnotice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/paymentreconciliation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/paymentreconciliation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/person.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/person.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/plandefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/plandefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/practitioner.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/practitioner.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/practitionerrole.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/practitionerrole.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/procedure.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/procedure.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/procedurerequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/procedurerequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/processrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/processrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/processresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/processresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/provenance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/provenance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/questionnaire.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/questionnaire.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/questionnaireresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/questionnaireresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/referralrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/referralrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/relatedperson.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/relatedperson.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/requestgroup.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/requestgroup.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/researchstudy.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/researchstudy.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/researchsubject.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/researchsubject.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/resource.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/resource.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/riskassessment.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/riskassessment.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/schedule.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/schedule.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/searchparameter.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/searchparameter.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/sequence.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/sequence.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/servicedefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/servicedefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/slot.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/slot.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/specimen.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/specimen.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/structuredefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/structuredefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/structuremap.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/structuremap.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/subscription.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/subscription.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/substance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/substance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/supplydelivery.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/supplydelivery.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/supplyrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/supplyrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/task.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/task.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/testreport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/testreport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/testscript.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/testscript.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/valueset.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/valueset.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/visionprescription.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/3_0_1/controllers/visionprescription.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/account.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/account.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/activitydefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/activitydefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/adverseevent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/adverseevent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/allergyintolerance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/allergyintolerance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/appointment.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/appointment.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/appointmentresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/appointmentresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/auditevent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/auditevent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/basic.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/basic.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/binary.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/binary.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/bodystructure.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/bodystructure.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/bundle.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/bundle.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/capabilitystatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/capabilitystatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/careplan.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/careplan.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/careteam.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/careteam.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/chargeitem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/chargeitem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/chargeitemdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/chargeitemdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/claim.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/claim.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/claimresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/claimresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/clinicalimpression.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/clinicalimpression.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/codesystem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/codesystem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/communication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/communication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/communicationrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/communicationrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/compartmentdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/compartmentdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/composition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/composition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/conceptmap.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/conceptmap.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/condition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/condition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/consent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/consent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/contract.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/contract.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/coverage.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/coverage.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/coverageeligibilityrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/coverageeligibilityrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/coverageeligibilityresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/coverageeligibilityresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/detectedissue.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/detectedissue.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/device.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/device.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/devicedefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/devicedefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/devicemetric.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/devicemetric.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/devicerequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/devicerequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/deviceusestatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/deviceusestatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/diagnosticreport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/diagnosticreport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/documentmanifest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/documentmanifest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/documentreference.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/documentreference.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/domainresource.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/domainresource.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/effectevidencesynthesis.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/effectevidencesynthesis.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/encounter.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/encounter.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/endpoint.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/endpoint.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/enrollmentrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/enrollmentrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/enrollmentresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/enrollmentresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/episodeofcare.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/episodeofcare.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/eventdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/eventdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/evidence.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/evidence.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/evidencevariable.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/evidencevariable.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/examplescenario.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/examplescenario.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/explanationofbenefit.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/explanationofbenefit.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/familymemberhistory.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/familymemberhistory.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/flag.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/flag.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/goal.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/goal.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/graphdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/graphdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/group.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/group.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/guidanceresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/guidanceresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/healthcareservice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/healthcareservice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/imagingstudy.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/imagingstudy.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/immunization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/immunization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/immunizationevaluation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/immunizationevaluation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/immunizationrecommendation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/immunizationrecommendation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/implementationguide.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/implementationguide.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/insuranceplan.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/insuranceplan.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/invoice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/invoice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/library.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/library.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/linkage.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/linkage.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/list.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/list.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/location.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/location.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/measure.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/measure.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/measurereport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/measurereport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/media.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/media.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationadministration.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationadministration.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationdispense.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationdispense.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationknowledge.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationknowledge.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationstatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicationstatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproduct.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproduct.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductauthorization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductauthorization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductcontraindication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductcontraindication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductindication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductindication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductinteraction.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductinteraction.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductpackaged.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductpackaged.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductpharmaceutical.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductpharmaceutical.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductundesirableeffect.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/medicinalproductundesirableeffect.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/messagedefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/messagedefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/messageheader.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/messageheader.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/molecularsequence.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/molecularsequence.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/namingsystem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/namingsystem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/nutritionorder.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/nutritionorder.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/observation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/observation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/operationdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/operationdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/organization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/organization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/organizationaffiliation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/organizationaffiliation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/patient.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/patient.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/paymentnotice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/paymentnotice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/paymentreconciliation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/paymentreconciliation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/person.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/person.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/plandefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/plandefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/practitioner.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/practitioner.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/practitionerrole.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/practitionerrole.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/procedure.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/procedure.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/provenance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/provenance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/questionnaire.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/questionnaire.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/questionnaireresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/questionnaireresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/relatedperson.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/relatedperson.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/requestgroup.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/requestgroup.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/researchdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/researchdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/researchelementdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/researchelementdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/researchstudy.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/researchstudy.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/researchsubject.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/researchsubject.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/resource.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/resource.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/riskassessment.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/riskassessment.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/riskevidencesynthesis.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/riskevidencesynthesis.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/schedule.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/schedule.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/searchparameter.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/searchparameter.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/servicerequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/servicerequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/slot.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/slot.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/specimen.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/specimen.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/specimendefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/specimendefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/structuredefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/structuredefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/structuremap.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/structuremap.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/subscription.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/subscription.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/substance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/substance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/substancespecification.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/substancespecification.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/supplydelivery.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/supplydelivery.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/supplyrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/supplyrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/task.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/task.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/terminologycapabilities.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/terminologycapabilities.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/testreport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/testreport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/testscript.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/testscript.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/valueset.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/valueset.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/verificationresult.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/verificationresult.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/visionprescription.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_0/controllers/visionprescription.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/account.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/account.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/activitydefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/activitydefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/adverseevent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/adverseevent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/allergyintolerance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/allergyintolerance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/appointment.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/appointment.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/appointmentresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/appointmentresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/auditevent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/auditevent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/basic.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/basic.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/binary.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/binary.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/bodystructure.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/bodystructure.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/bundle.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/bundle.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/capabilitystatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/capabilitystatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/careplan.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/careplan.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/careteam.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/careteam.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/chargeitem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/chargeitem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/chargeitemdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/chargeitemdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/claim.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/claim.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/claimresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/claimresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/clinicalimpression.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/clinicalimpression.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/codesystem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/codesystem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/communication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/communication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/communicationrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/communicationrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/compartmentdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/compartmentdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/composition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/composition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/conceptmap.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/conceptmap.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/condition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/condition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/consent.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/consent.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/contract.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/contract.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/coverage.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/coverage.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/coverageeligibilityrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/coverageeligibilityrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/coverageeligibilityresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/coverageeligibilityresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/detectedissue.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/detectedissue.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/device.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/device.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/devicedefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/devicedefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/devicemetric.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/devicemetric.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/devicerequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/devicerequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/deviceusestatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/deviceusestatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/diagnosticreport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/diagnosticreport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/documentmanifest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/documentmanifest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/documentreference.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/documentreference.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/domainresource.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/domainresource.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/effectevidencesynthesis.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/effectevidencesynthesis.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/encounter.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/encounter.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/endpoint.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/endpoint.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/enrollmentrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/enrollmentrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/enrollmentresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/enrollmentresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/episodeofcare.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/episodeofcare.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/eventdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/eventdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/evidence.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/evidence.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/evidencevariable.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/evidencevariable.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/examplescenario.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/examplescenario.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/explanationofbenefit.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/explanationofbenefit.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/familymemberhistory.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/familymemberhistory.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/flag.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/flag.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/goal.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/goal.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/graphdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/graphdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/group.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/group.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/guidanceresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/guidanceresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/healthcareservice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/healthcareservice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/imagingstudy.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/imagingstudy.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/immunization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/immunization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/immunizationevaluation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/immunizationevaluation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/immunizationrecommendation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/immunizationrecommendation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/implementationguide.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/implementationguide.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/insuranceplan.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/insuranceplan.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/invoice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/invoice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/library.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/library.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/linkage.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/linkage.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/list.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/list.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/location.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/location.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/measure.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/measure.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/measurereport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/measurereport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/media.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/media.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationadministration.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationadministration.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationdispense.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationdispense.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationknowledge.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationknowledge.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationstatement.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicationstatement.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproduct.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproduct.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductauthorization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductauthorization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductcontraindication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductcontraindication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductindication.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductindication.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductinteraction.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductinteraction.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductpackaged.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductpackaged.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductpharmaceutical.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductpharmaceutical.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductundesirableeffect.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/medicinalproductundesirableeffect.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/messagedefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/messagedefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/messageheader.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/messageheader.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/molecularsequence.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/molecularsequence.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/namingsystem.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/namingsystem.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/nutritionorder.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/nutritionorder.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/observation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/observation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/operationdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/operationdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/organization.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/organization.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/organizationaffiliation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/organizationaffiliation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/patient.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/patient.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/paymentnotice.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/paymentnotice.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/paymentreconciliation.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/paymentreconciliation.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/person.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/person.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/plandefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/plandefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/practitioner.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/practitioner.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/practitionerrole.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/practitionerrole.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/procedure.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/procedure.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/provenance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/provenance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/questionnaire.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/questionnaire.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/questionnaireresponse.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/questionnaireresponse.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/relatedperson.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/relatedperson.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/requestgroup.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/requestgroup.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/researchdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/researchdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/researchelementdefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/researchelementdefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/researchstudy.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/researchstudy.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/researchsubject.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/researchsubject.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/resource.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/resource.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/riskassessment.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/riskassessment.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/riskevidencesynthesis.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/riskevidencesynthesis.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/schedule.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/schedule.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/searchparameter.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/searchparameter.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/servicerequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/servicerequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/slot.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/slot.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/specimen.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/specimen.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/specimendefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/specimendefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/structuredefinition.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/structuredefinition.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/structuremap.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/structuremap.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/subscription.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/subscription.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/substance.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/substance.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/substancespecification.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/substancespecification.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/supplydelivery.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/supplydelivery.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/supplyrequest.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/supplyrequest.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/task.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/task.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/terminologycapabilities.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/terminologycapabilities.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/testreport.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/testreport.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/testscript.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/testscript.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/valueset.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/valueset.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/verificationresult.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/verificationresult.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/visionprescription.controller.js
+++ b/packages/node-fhir-server-core/src/server/resources/4_0_1/controllers/visionprescription.controller.js
@@ -1,4 +1,4 @@
-const handler = require('@asymmetrik/fhir-response-util');
+const handler = require('@bluehalo/fhir-response-util');
 
 /**
  * @function search

--- a/packages/node-fhir-server-core/src/server/router.js
+++ b/packages/node-fhir-server-core/src/server/router.js
@@ -87,7 +87,7 @@ function enableOperationRoutesForProfile(app, config, profile, key, parameters, 
   let errorMessage =
     `Invalid operation configuration for ${key}. Please ` +
     'see the Operations wiki for instructions on how to use operations. ' +
-    'https://github.com/Asymmetrik/node-fhir-server-core/wiki/Operations';
+    'https://github.com/BlueHalo/node-fhir-server-core/wiki/Operations';
 
   for (let op of profile.operation) {
     let functionName = hyphenToCamelcase(op.name || '');
@@ -243,7 +243,7 @@ function enableResourceRoutes(app, config, corsDefaults) {
       throw new Error(
         `${profileName} is an invalid profile configuration, please see the wiki for ` +
           'instructions on how to enable a profile in your server, ' +
-          'https://github.com/Asymmetrik/node-fhir-server-core/wiki/Profile'
+          'https://github.com/BlueHalo/node-fhir-server-core/wiki/Profile'
       );
     }
 

--- a/packages/node-fhir-server-core/src/server/router.test.js
+++ b/packages/node-fhir-server-core/src/server/router.test.js
@@ -74,7 +74,7 @@ describe('Router Tests', () => {
   test('should throw for invalid profile configurations', () => {
     // Both of these errors should link them to the profile wiki
     // to help them fix the issue
-    let profileWiki = 'https://github.com/Asymmetrik/node-fhir-server-core/wiki/Profile';
+    let profileWiki = 'https://github.com/BlueHalo/node-fhir-server-core/wiki/Profile';
     // test an invalid version
     config.profiles.patient.versions = ['2_0_0'];
     expect(() => {
@@ -103,7 +103,7 @@ describe('Router Tests', () => {
 
   test('should throw for invalid operation configurations', () => {
     // All errors should direct them to the operations wiki page
-    let operationWiki = 'https://github.com/Asymmetrik/node-fhir-server-core/wiki/Operations';
+    let operationWiki = 'https://github.com/BlueHalo/node-fhir-server-core/wiki/Operations';
     // Should throw for missing name, route, method, or a matching controller
     // Name throws first
     config.profiles.patient.operation = [{}];

--- a/packages/node-fhir-server-core/src/server/server.js
+++ b/packages/node-fhir-server-core/src/server/server.js
@@ -81,7 +81,7 @@ function validate(config) {
   invariant(
     !config.server.ssl || (config.server.ssl && config.server.ssl.key && config.server.ssl.cert),
     'Invalid SSL Configuration, Please see the Wiki for a guide on how to setup SSL. ' +
-      'See https://github.com/Asymmetrik/node-fhir-server-core/blob/master/docs/ServerConfiguration.md'
+      'See https://github.com/BlueHalo/node-fhir-server-core/blob/master/docs/ServerConfiguration.md'
   );
 
   // If we have no profiles configured, notify them now
@@ -89,7 +89,7 @@ function validate(config) {
     Object.keys(config.profiles).length > 0,
     'No profiles configured. We do not enable any profiles by default so please ' +
       'review the profile wiki for how to enable profiles and capabilities. ' +
-      'See https://github.com/Asymmetrik/node-fhir-server-core/blob/master/docs/ConfiguringProfiles.md'
+      'See https://github.com/BlueHalo/node-fhir-server-core/blob/master/docs/ConfiguringProfiles.md'
   );
 
   // We need to verify that each provided key is valid and that the config
@@ -101,7 +101,7 @@ function validate(config) {
     errors.length === 0,
     'Encountered the following errors attempting to load your provided profiles:' +
       `\n${errors.join('\n')}\n` +
-      'See https://github.com/Asymmetrik/node-fhir-server-core/blob/master/docs/ConfiguringProfiles.md'
+      'See https://github.com/BlueHalo/node-fhir-server-core/blob/master/docs/ConfiguringProfiles.md'
   );
 }
 
@@ -337,7 +337,7 @@ class Server {
     invariant(
       port || server.port,
       'Missing port. Please provide a port when initializing the server. See ' +
-        'https://github.com/Asymmetrik/node-fhir-server-core/blob/master/docs/ServerConfiguration.md'
+        'https://github.com/BlueHalo/node-fhir-server-core/blob/master/docs/ServerConfiguration.md'
     );
 
     // Update the express app to be in instance of createServer

--- a/packages/node-fhir-server-core/yarn.lock
+++ b/packages/node-fhir-server-core/yarn.lock
@@ -9,16 +9,6 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@asymmetrik/fhir-response-util@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@asymmetrik/fhir-response-util/-/fhir-response-util-1.2.4.tgz#8269c4d8a7d639e3bef7225a6ccfa9df5ea5a0bb"
-  integrity sha512-GL75AWd0kYkfBv8YVZv1yLpIqzSx/TA5Se9GGGg3YlIrUNoVqqO6aRLGGjuYHJGJY56h2LnV8z9f9+lIl/31kg==
-
-"@asymmetrik/sof-scope-checker@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@asymmetrik/sof-scope-checker/-/sof-scope-checker-1.0.7.tgz#f56580977ef4b965b3ae41007ce9b7bbba86c920"
-  integrity sha512-QzLGDRMaVX/R/iAqQu4MuDV29d/0mvSyT1i4p/C3Xi5sSQXPtSa8e/uUChBfpPGOdbIQv1Uv84tkRifRKUKtZA==
-
 "@babel/cli@^7.15.7":
   version "7.17.6"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.17.6.tgz#169e5935f1795f0b62ded5a2accafeedfe5c5363"
@@ -947,6 +937,16 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@bluehalo/fhir-response-util@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@bluehalo/fhir-response-util/-/fhir-response-util-1.2.4.tgz#5bba9f631d3ca17559ff2efcfc59e9367d04939e"
+  integrity sha512-VcStCsLT/rx9c7ReIt+6Bty3Myt1tyShyg1J5yn2CiG11M5qlOJfSWl7YT1bDzVLjzxhl96vTBqG0JWATzv/7g==
+
+"@bluehalo/sof-scope-checker@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@bluehalo/sof-scope-checker/-/sof-scope-checker-1.0.7.tgz#eba5e6c9b408ecc91c1083531db12bfa2a6afea0"
+  integrity sha512-WnyGIBiTqwcvFINB6qBzPJK2TQefEb2Cwd58ACk+XV82mym/infMTvH8H1YwBUzmhBGvvmpK2U7AlHHNyjWpHw==
 
 "@colors/colors@1.5.0":
   version "1.5.0"

--- a/packages/sof-graphql-invariant/CHANGELOG.md
+++ b/packages/sof-graphql-invariant/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.0.0](https://github.com/Asymmetrik/node-fhir-server-core/compare/chore/convert-repo-to-monorepo...task/upgrade-graphql-15-5-3) (2021-09-16)
+## [2.0.0](https://github.com/BlueHalo/node-fhir-server-core/compare/chore/convert-repo-to-monorepo...task/upgrade-graphql-15-5-3) (2021-09-16)
 
 ### Update Dependency
 
@@ -11,25 +11,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** This is a breaking change and requires code updates
 
-## [1.1.1](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/sof-graphql-invariant@1.0.3...@asymmetrik/sof-graphql-invariant@1.1.1) (2019-04-05)
+## [1.1.1](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/sof-graphql-invariant@1.0.3...@bluehalo/sof-graphql-invariant@1.1.1) (2019-04-05)
 
-**Note:** Version bump only for package @asymmetrik/sof-graphql-invariant
+**Note:** Version bump only for package @bluehalo/sof-graphql-invariant
 
-# [1.1.0](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/sof-graphql-invariant@1.0.3...@asymmetrik/sof-graphql-invariant@1.1.0) (2019-03-20)
+# [1.1.0](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/sof-graphql-invariant@1.0.3...@bluehalo/sof-graphql-invariant@1.1.0) (2019-03-20)
 
 ### Features
 
-- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/Asymmetrik/phx-tools/commit/fefce17))
-- added lockfiles for each package ([f8d9a31](https://github.com/Asymmetrik/phx-tools/commit/f8d9a31))
+- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/BlueHalo/phx-tools/commit/fefce17))
+- added lockfiles for each package ([f8d9a31](https://github.com/BlueHalo/phx-tools/commit/f8d9a31))
 
-## [1.0.3](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/sof-graphql-invariant@1.0.2...@asymmetrik/sof-graphql-invariant@1.0.3) (2019-02-13)
-
-### Bug Fixes
-
-- Fixed paths on repository url and homepage ([#9](https://github.com/Asymmetrik/phx-tools/issues/9)) ([d662ec8](https://github.com/Asymmetrik/phx-tools/commit/d662ec8))
-
-## [1.0.2](https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-graphql-invariant/compare/@asymmetrik/sof-graphql-invariant@1.0.1...@asymmetrik/sof-graphql-invariant@1.0.2) (2019-01-04)
+## [1.0.3](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/sof-graphql-invariant@1.0.2...@bluehalo/sof-graphql-invariant@1.0.3) (2019-02-13)
 
 ### Bug Fixes
 
-- fixed issues with env variables expecting to be booleans ([#6](https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-graphql-invariant/issues/6)) ([0577065](https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-graphql-invariant/commit/0577065))
+- Fixed paths on repository url and homepage ([#9](https://github.com/BlueHalo/phx-tools/issues/9)) ([d662ec8](https://github.com/BlueHalo/phx-tools/commit/d662ec8))
+
+## [1.0.2](https://github.com/BlueHalo/phx-tools/tree/master/packages/sof-graphql-invariant/compare/@bluehalo/sof-graphql-invariant@1.0.1...@bluehalo/sof-graphql-invariant@1.0.2) (2019-01-04)
+
+### Bug Fixes
+
+- fixed issues with env variables expecting to be booleans ([#6](https://github.com/BlueHalo/phx-tools/tree/master/packages/sof-graphql-invariant/issues/6)) ([0577065](https://github.com/BlueHalo/phx-tools/tree/master/packages/sof-graphql-invariant/commit/0577065))

--- a/packages/sof-graphql-invariant/README.md
+++ b/packages/sof-graphql-invariant/README.md
@@ -6,7 +6,7 @@
 # Install
 
 ```shell
-yarn add @asymmetrik/sof-graphql-invariant
+yarn add @bluehalo/sof-graphql-invariant
 ```
 
 ## Usage
@@ -18,7 +18,7 @@ requests on a resource level instead of across the entire request and will
 reject them in a manner that meets conformance standards for FHIR and GraphQL.
 
 ```javascript
-const scopeInvariant = require('@asymmetrik/sof-graphql-invariant');
+const scopeInvariant = require('@bluehalo/sof-graphql-invariant');
 
 // NOTE: All the paths for the following modules are fictional, you will need
 // to provide your own path to these resources, these are for example only
@@ -53,7 +53,7 @@ let root = new GraphQLObjectType({
 });
 ```
 
-See [sof-graphql-invariant tests](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages/sof-graphql-invariant/index.test.js) for more usage examples.
+See [sof-graphql-invariant tests](https://github.com/BlueHalo/node-fhir-server-core/tree/master/packages/sof-graphql-invariant/index.test.js) for more usage examples.
 
 ### Environment variables
 
@@ -76,7 +76,7 @@ Value: `true`
 If you use this invariant, it will check scopes on all incoming requests. If you want to disable this or provide a toggle mechanism, you can do so by setting an environment variable. To disable authentication, set `SOF_AUTHENTICATION` to false. It will only disable authentication if this is explicitly set to false.
 
 ```javascript
-const scopeInvariant = require('@asymmetrik/sof-graphql-invariant');
+const scopeInvariant = require('@bluehalo/sof-graphql-invariant');
 
 // Set the ENV
 process.env.SOF_AUTHENTICATION = 'false';
@@ -104,7 +104,7 @@ const ExamplePatientQuery = {
 Sometimes it is useful to enable authentication in development but disable it when you are using the graphiql explorer. This requires two things. First is an environment variable stating you are using it, `HAS_GRAPHIQL`. Second, that the endpoint ends with `$graphiql`. If you do this, you can have authentication enabled on your graphql schemas but not if the request is coming from GraphiQL.
 
 ```javascript
-const scopeInvariant = require('@asymmetrik/sof-graphql-invariant');
+const scopeInvariant = require('@bluehalo/sof-graphql-invariant');
 // Set the ENV
 process.env.HAS_GRAPHIQL = 'true';
 
@@ -128,7 +128,7 @@ const ExamplePatientMutation = {
 
 ## Arguments
 
-`@asymmetrik/sof-graphql-invariant` exports a single function which takes two arguments. One is a set of options and the other is a resolver function.
+`@bluehalo/sof-graphql-invariant` exports a single function which takes two arguments. One is a set of options and the other is a resolver function.
 
 ### Options
 

--- a/packages/sof-graphql-invariant/index.js
+++ b/packages/sof-graphql-invariant/index.js
@@ -1,4 +1,4 @@
-const scopeChecker = require('@asymmetrik/sof-scope-checker');
+const scopeChecker = require('@bluehalo/sof-scope-checker');
 const { GraphQLError, coerceInputValue, isInputType } = require('graphql');
 
 /**

--- a/packages/sof-graphql-invariant/package.json
+++ b/packages/sof-graphql-invariant/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/sof-graphql-invariant",
+  "name": "@bluehalo/sof-graphql-invariant",
   "version": "2.0.0",
   "description": "Smart on FHIR scope checker for GraphQL",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/sof-graphql-invariant"
@@ -15,7 +15,7 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "@asymmetrik/sof-scope-checker": "^1.0.7",
+    "@bluehalo/sof-scope-checker": "^1.0.7",
     "graphql": "^15.6.0"
   },
   "scripts": {

--- a/packages/sof-scope-checker/CHANGELOG.md
+++ b/packages/sof-scope-checker/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.0.2](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/sof-scope-checker@1.0.1...@asymmetrik/sof-scope-checker@1.0.2) (2019-02-13)
+## [1.0.2](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/sof-scope-checker@1.0.1...@bluehalo/sof-scope-checker@1.0.2) (2019-02-13)
 
 ### Bug Fixes
 
-- Fixed paths on repository url and homepage ([#9](https://github.com/Asymmetrik/phx-tools/issues/9)) ([d662ec8](https://github.com/Asymmetrik/phx-tools/commit/d662ec8))
+- Fixed paths on repository url and homepage ([#9](https://github.com/BlueHalo/phx-tools/issues/9)) ([d662ec8](https://github.com/BlueHalo/phx-tools/commit/d662ec8))

--- a/packages/sof-scope-checker/README.md
+++ b/packages/sof-scope-checker/README.md
@@ -5,13 +5,13 @@
 # Install
 
 ```shell
-yarn add @asymmetrik/sof-scope-checker
+yarn add @bluehalo/sof-scope-checker
 ```
 
 ## Usage
 
 ```
-const scopeChecker = require('@asymmetrik/sof-scope-checker');
+const scopeChecker = require('@bluehalo/sof-scope-checker');
 
 let hasValidScopes = (name, action) => {
   return function (req, res, next) {
@@ -36,13 +36,13 @@ app.get(
 )
 ```
 
-See [sof-scope-checker tests](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages/sof-scope-checker/index.test.js) for more usage examples.
+See [sof-scope-checker tests](https://github.com/BlueHalo/node-fhir-server-core/tree/master/packages/sof-scope-checker/index.test.js) for more usage examples.
 
 NOTE: The error returned is an extension of the native JS error. It adds a type property to the error which can have a value of 'internal' representing a misconfiguration, or 'forbidden' representing a case where the scopes are not sufficient.
 
 ## Arguments
 
-`@asymmetrik/sof-scope-checker` exports a single function which takes three arguments.
+`@bluehalo/sof-scope-checker` exports a single function which takes three arguments.
 
 #### `name`
 

--- a/packages/sof-scope-checker/package.json
+++ b/packages/sof-scope-checker/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/sof-scope-checker",
+  "name": "@bluehalo/sof-scope-checker",
   "version": "1.0.7",
   "description": "Smart on FHIR scope checker",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/sof-scope-checker"

--- a/packages/sof-strategy/CHANGELOG.md
+++ b/packages/sof-strategy/CHANGELOG.md
@@ -3,31 +3,31 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.1.5](https://github.com/Asymmetrik/node-fhir-server-core/compare/chore/convert-repo-to-monorepo...task/upgrade-graphql-15-5-3) (2021-09-16)
+## [1.1.5](https://github.com/BlueHalo/node-fhir-server-core/compare/chore/convert-repo-to-monorepo...task/upgrade-graphql-15-5-3) (2021-09-16)
 
 ### Update Dependency
 
 - update superagent to 6.1.0
 
-## [1.1.1](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/sof-strategy@1.0.3...@asymmetrik/sof-strategy@1.1.1) (2019-04-05)
+## [1.1.1](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/sof-strategy@1.0.3...@bluehalo/sof-strategy@1.1.1) (2019-04-05)
 
-**Note:** Version bump only for package @asymmetrik/sof-strategy
+**Note:** Version bump only for package @bluehalo/sof-strategy
 
-# [1.1.0](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/sof-strategy@1.0.3...@asymmetrik/sof-strategy@1.1.0) (2019-03-20)
+# [1.1.0](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/sof-strategy@1.0.3...@bluehalo/sof-strategy@1.1.0) (2019-03-20)
 
 ### Features
 
-- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/Asymmetrik/phx-tools/commit/fefce17))
-- added lockfiles for each package ([f8d9a31](https://github.com/Asymmetrik/phx-tools/commit/f8d9a31))
+- add fhir-qb and fhir-qb-mongo ([fefce17](https://github.com/BlueHalo/phx-tools/commit/fefce17))
+- added lockfiles for each package ([f8d9a31](https://github.com/BlueHalo/phx-tools/commit/f8d9a31))
 
-## [1.0.3](https://github.com/Asymmetrik/phx-tools/compare/@asymmetrik/sof-strategy@1.0.2...@asymmetrik/sof-strategy@1.0.3) (2019-02-13)
-
-### Bug Fixes
-
-- Fixed paths on repository url and homepage ([#9](https://github.com/Asymmetrik/phx-tools/issues/9)) ([d662ec8](https://github.com/Asymmetrik/phx-tools/commit/d662ec8))
-
-## [1.0.2](https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-strategy/compare/@asymmetrik/sof-strategy@1.0.1...@asymmetrik/sof-strategy@1.0.2) (2019-01-04)
+## [1.0.3](https://github.com/BlueHalo/phx-tools/compare/@bluehalo/sof-strategy@1.0.2...@bluehalo/sof-strategy@1.0.3) (2019-02-13)
 
 ### Bug Fixes
 
-- upgraded superagent to non-beta version ([#7](https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-strategy/issues/7)) ([caa1e37](https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-strategy/commit/caa1e37))
+- Fixed paths on repository url and homepage ([#9](https://github.com/BlueHalo/phx-tools/issues/9)) ([d662ec8](https://github.com/BlueHalo/phx-tools/commit/d662ec8))
+
+## [1.0.2](https://github.com/BlueHalo/phx-tools/tree/master/packages/sof-strategy/compare/@bluehalo/sof-strategy@1.0.1...@bluehalo/sof-strategy@1.0.2) (2019-01-04)
+
+### Bug Fixes
+
+- upgraded superagent to non-beta version ([#7](https://github.com/BlueHalo/phx-tools/tree/master/packages/sof-strategy/issues/7)) ([caa1e37](https://github.com/BlueHalo/phx-tools/tree/master/packages/sof-strategy/commit/caa1e37))

--- a/packages/sof-strategy/README.md
+++ b/packages/sof-strategy/README.md
@@ -5,14 +5,14 @@
 ## Install
 
 ```shell
-yarn add @asymmetrik/sof-strategy
+yarn add @bluehalo/sof-strategy
 ```
 
 ## Usage
 
 ```javascript
 // Returns a helper function to setup your strategy
-const smartBearerStrategy = require('@asymmetrik/sof-strategy');
+const smartBearerStrategy = require('@bluehalo/sof-strategy');
 const passport = require('passport');
 
 // Create our strategy by giving it some config options, all are required
@@ -35,11 +35,11 @@ let options = { session: false };
 app.use('/some/protected/route/', passport.authenticate(name, options), someRouteController);
 ```
 
-See [sof-strategy tests](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/packages/sof-strategy/index.test.js) for more usage examples.
+See [sof-strategy tests](https://github.com/BlueHalo/node-fhir-server-core/tree/master/packages/sof-strategy/index.test.js) for more usage examples.
 
 ## Arguments
 
-`@asymmetrik/sof-strategy` exports a single function which takes a single options argument with the following properties.
+`@bluehalo/sof-strategy` exports a single function which takes a single options argument with the following properties.
 
 #### `introspectionUrl`
 

--- a/packages/sof-strategy/package.json
+++ b/packages/sof-strategy/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@asymmetrik/sof-strategy",
+  "name": "@bluehalo/sof-strategy",
   "version": "1.1.6",
   "description": "Smart on FHIR authorization strategy for passport",
-  "homepage": "https://github.com/Asymmetrik/node-fhir-server-core",
+  "homepage": "https://github.com/BlueHalo/node-fhir-server-core",
   "repository": {
     "type": "git",
     "directory": "packages/sof-strategy"


### PR DESCRIPTION
Changes to update all references from "Asymmetrik" to "BlueHalo"

These packages will now be under the BlueHalo organization on NPM, and the Asymmetrik packages will be deprecated.

https://www.npmjs.com/org/bluehalo

The changes in this PR include replacing Asymmetrik with BlueHalo in the docs, and updating the `require` statements with `@bluehalo/...` in the code

ex. `require('@asymmetrik/node-fhir-server-core')` => `require('@bluehalo/node-fhir-server-core')`