### PR TITLE
feat: allow passing of object to auth strategy service

### DIFF
--- a/docs/ServerConfiguration.md
+++ b/docs/ServerConfiguration.md
@@ -112,8 +112,8 @@ Here is an example config with all the currently supported options. See descript
 
 #### `auth.strategy.service`
 
-- **Type:** `string`
-- **Description:** A relative path to a authentication service module. It currently must export a strategy property which is set to a valid [passport strategy](http://www.passportjs.org/packages/).
+- **Type:** `string|object`
+- **Description:** A relative path to an authentication service module, or the actual module itself (e.g. `require('path/to/service')`). It currently must export a strategy property which is set to a valid [passport strategy](http://www.passportjs.org/packages/).
 - **Required:** false
 - **Default:** undefined
 

--- a/packages/node-fhir-server-core/src/server/server.js
+++ b/packages/node-fhir-server-core/src/server/server.js
@@ -200,7 +200,8 @@ class Server {
 
   configurePassport() {
     if (this.config.auth && this.config.auth.strategy) {
-      let { strategy } = require(path.resolve(this.config.auth.strategy.service));
+      const service = this.config.auth.strategy.service;
+      let { strategy } = typeof service === 'string' ? require(path.resolve(service)) : service;
       passport.use(strategy);
     }
 


### PR DESCRIPTION
This change will allow passing of object to auth.strategy.service. Similar possibility is already present in profile configuration service, so this change will unify the behaviour.

Reason:
Currently it is not possible to pass object to  auth.strategy.service, only a string path which is then loaded using `require`. However, this doesn't work in ES module project where only `import` statement is allowed. On the other hand, profile configuration supports either path to a service or the service itself, which means in ES module project the user can load the service using `import` and pass the loaded object.